### PR TITLE
ImportFromの対応

### DIFF
--- a/jig/collector/application/__init__.py
+++ b/jig/collector/application/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 
 from jig.collector.domain import SourceCode
@@ -5,20 +6,24 @@ from jig.collector.domain import SourceCodeCollectRequest
 from jig.collector.domain import SourceFile
 
 
+@dataclasses.dataclass(frozen=True)
 class SourceCodeCollector:
+    root_path: str
+
     def collect(self, target_path: str) -> SourceCode:
         # TODO: target_path が存在するかチェック
 
         source = open(target_path).read()
 
         return SourceCodeCollectRequest(
+            root_path=self.root_path,
             file=SourceFile(
                 path=target_path, content=source, size=os.path.getsize(target_path),
             ),
         ).build()
 
 
-def collect(target_path: str) -> SourceCode:
-    collector = SourceCodeCollector()
+def collect(root_path: str, target_path: str) -> SourceCode:
+    collector = SourceCodeCollector(root_path=root_path)
 
     return collector.collect(target_path=target_path)

--- a/jig/collector/domain/__init__.py
+++ b/jig/collector/domain/__init__.py
@@ -2,7 +2,7 @@ import dataclasses
 import os
 from typing import List
 
-from jig.collector.jig_ast import JigAST
+from jig.collector.jig_ast import JigAST, ImportFrom
 
 
 @dataclasses.dataclass(frozen=True)
@@ -18,6 +18,47 @@ class ImportModule:
 @dataclasses.dataclass(frozen=True)
 class ImportModuleCollection:
     _modules: List[ImportModule]
+
+    def __len__(self) -> int:
+        return len(self._modules)
+
+    def __contains__(self, item: ImportModule):
+        return item in self._modules
+
+    # TODO: root_path, current_path をドメインオブジェクトにする
+    @classmethod
+    def build_by_import_from_ast(
+        cls, root_path: str, current_path: str, import_from: ImportFrom
+    ) -> "ImportModuleCollection":
+        level = import_from.level if import_from.level is not None else 0
+        prefix = cls._get_path_prefix(root_path, current_path, level)
+
+        imports = []
+        for alias in import_from.names:
+            # prefixもimport_from.moduleも存在しない（None）なことがあるのでフィルタする
+            # prefix: from xxx が相対パス指定じゃない場合None
+            # import_from.module: from句に名前指定がないときNone（from . や from .. など）
+            path_list = list(
+                filter(lambda x: x, [prefix, import_from.module, alias.name])
+            )
+
+            path = ModulePath(".".join(path_list))
+
+            imports.append(ImportModule(path))
+
+        return cls(_modules=imports)
+
+    @classmethod
+    def _get_path_prefix(cls, root_path: str, current_path: str, level: int):
+        if level < 1:
+            return None
+
+        relative_path = os.path.relpath(current_path, root_path)
+
+        path_list = relative_path.split(os.sep)
+
+        # level分遡ったパーツを結合する
+        return ".".join(path_list[:-level])
 
 
 @dataclasses.dataclass(frozen=True)
@@ -44,6 +85,8 @@ class SourceCodeAST:
         for import_node in self._ast.imports():
             for name in import_node.names:
                 imports.append(ImportModule(module_path=ModulePath(_path=name.name)))
+
+        # TODO: ImportFromも取得してがっちゃんこする
 
         return ImportModuleCollection(imports)
 

--- a/jig/collector/jig_ast/__init__.py
+++ b/jig/collector/jig_ast/__init__.py
@@ -22,9 +22,18 @@ class ImportFrom:
     level: fromのインポートレベル。'from os' => 0, 'from .' => 1, 'from ..' => 2
            levelがNoneになる条件は不明だが、ドキュメントの定義に合わせてOptional型で定義している
     """
+
     module: Optional[str]
     names: List[Alias]
     level: Optional[int]
+
+    @classmethod
+    def from_ast(cls, import_from: ast.ImportFrom) -> "ImportFrom":
+        names = [
+            Alias(name=alias.name, asname=alias.asname) for alias in import_from.names
+        ]
+
+        return cls(module=import_from.module, names=names, level=import_from.level)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -66,8 +75,13 @@ class JigAST:
 
         nodes = []
         for from_node in visitor.import_froms:
-            names = [Alias(name=name_alias.name, asname=name_alias.asname) for name_alias in from_node.names]
+            names = [
+                Alias(name=name_alias.name, asname=name_alias.asname)
+                for name_alias in from_node.names
+            ]
 
-            nodes.append(ImportFrom(module=from_node.module, names=names, level=from_node.level))
+            nodes.append(
+                ImportFrom(module=from_node.module, names=names, level=from_node.level)
+            )
 
         return nodes

--- a/main.py
+++ b/main.py
@@ -1,7 +1,11 @@
+import os
 import sys
 
 from jig.collector.application import collect
 
 if __name__ == "__main__":
-    result = collect(target_path=sys.argv[1])
+    # とりあえずこのmain.pyファイルのパスをルートとする
+    root_path = os.path.dirname(os.path.abspath(__file__))
+
+    result = collect(root_path=root_path, target_path=sys.argv[1])
     print(result)

--- a/tests/collector/domain/helper.py
+++ b/tests/collector/domain/helper.py
@@ -1,0 +1,10 @@
+from typed_ast import ast3 as ast
+from jig.collector.jig_ast import ImportFrom
+
+
+def parse_import_from(line: str) -> ImportFrom:
+    import_from_ast = ast.parse(line).body[0]
+
+    assert isinstance(import_from_ast, ast.ImportFrom)
+
+    return ImportFrom.from_ast(import_from_ast)

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -1,0 +1,86 @@
+from jig.collector.domain import ImportModule, ModulePath, ImportModuleCollection
+from .helper import parse_import_from
+
+
+class TestImportModuleCollectionBuildByImportFromAST:
+    ROOT_PATH = "/jig-py"
+    CURRENT_PATH = "/jig-py/jig/collector/domain/__init__.py"
+
+    def test_builtin_module(self):
+        import_from = parse_import_from("from os import path")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert ImportModule(ModulePath("os.path")) in import_modules
+
+    def test_multiple_import_module(self):
+        import_from = parse_import_from("from datetime import datetime, timezone")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 2
+        assert ImportModule(ModulePath("datetime.datetime")) in import_modules
+        assert ImportModule(ModulePath("datetime.timezone")) in import_modules
+
+    def test_external_module(self):
+        import_from = parse_import_from("from typed_ast import ast3 as ast")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert ImportModule(ModulePath("typed_ast.ast3")) in import_modules
+
+    def test_import_from_current_path(self):
+        import_from = parse_import_from("from . import sibling")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert (
+            ImportModule(ModulePath("jig.collector.domain.sibling")) in import_modules
+        )
+
+    def test_import_from_current_path_with_module_name(self):
+        import_from = parse_import_from("from .sibling import submodule")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert (
+            ImportModule(ModulePath("jig.collector.domain.sibling.submodule"))
+            in import_modules
+        )
+
+    def test_import_from_parent_path(self):
+        import_from = parse_import_from("from .. import jig_ast")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert ImportModule(ModulePath("jig.collector.jig_ast")) in import_modules
+
+    def test_import_from_parent_path_with_module_name(self):
+        import_from = parse_import_from("from ..jig_ast import submodule")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            self.ROOT_PATH, self.CURRENT_PATH, import_from
+        )
+
+        assert len(import_modules) == 1
+        assert (
+            ImportModule(ModulePath("jig.collector.jig_ast.submodule"))
+            in import_modules
+        )

--- a/tests/collector/domain/test_source_code_ast.py
+++ b/tests/collector/domain/test_source_code_ast.py
@@ -1,0 +1,70 @@
+from jig.collector.domain import (
+    SourceCodeAST,
+    SourceFile,
+    ModulePath,
+    ImportModule,
+    ImportModuleCollection,
+)
+
+
+def collection(*args):
+    modules = [ImportModule(ModulePath(p)) for p in args]
+
+    return ImportModuleCollection(modules)
+
+
+class TestSourceCodeASTGetImports:
+    ROOT_PATH = "/jig-py"
+    SOURCE_PATH = "/jig-py/jig/collector/domain/__init__.py"
+
+    def test_multiple_modules(self):
+        content = """
+import os, datetime
+        """
+
+        source = SourceFile(path=self.SOURCE_PATH, content=content, size=len(content))
+        ast = SourceCodeAST.build(root_path=self.ROOT_PATH, source=source)
+
+        assert ast.get_imports() == collection("os", "datetime")
+
+    def test_multiple_lines(self):
+        content = """
+import os
+import datetime as dt
+        """
+
+        source = SourceFile(path=self.SOURCE_PATH, content=content, size=len(content))
+        ast = SourceCodeAST.build(root_path=self.ROOT_PATH, source=source)
+
+        assert ast.get_imports() == collection("os", "datetime")
+
+    def test_import_from(self):
+        content = """
+from os import path
+        """
+
+        source = SourceFile(path=self.SOURCE_PATH, content=content, size=len(content))
+        ast = SourceCodeAST.build(root_path=self.ROOT_PATH, source=source)
+
+        assert ast.get_imports() == collection("os.path")
+
+    def test_mixed_import(self):
+        content = """
+import os
+import datetime as dt
+from os import path
+from . import submodule
+from .. import jig_ast
+        """
+
+        source = SourceFile(path=self.SOURCE_PATH, content=content, size=len(content))
+        ast = SourceCodeAST.build(root_path=self.ROOT_PATH, source=source)
+
+        modules = [
+            "os",
+            "datetime",
+            "os.path",
+            "jig.collector.domain.submodule",
+            "jig.collector.jig_ast",
+        ]
+        assert ast.get_imports() == collection(*modules)

--- a/tests/collector/jig_ast/test_jig_ast.py
+++ b/tests/collector/jig_ast/test_jig_ast.py
@@ -1,4 +1,4 @@
-from jig.collector.jig_ast import Import
+from jig.collector.jig_ast import Import, ImportFrom
 from jig.collector.jig_ast import JigAST
 
 
@@ -18,3 +18,17 @@ class Sample:
         assert isinstance(imports[0], Import)
         assert len(imports[0].names) == 1
         assert imports[0].names[0].name == "dataclasses"
+
+    def test_simple_import_from(self):
+        source = """
+from typing import Optional
+        """
+
+        nodes = JigAST.parse(source).import_froms()
+
+        assert len(nodes) == 1
+        assert isinstance(nodes[0], ImportFrom)
+        assert len(nodes[0].names) == 1
+        assert nodes[0].module == "typing"
+        assert nodes[0].names[0].name == "Optional"
+        assert nodes[0].level == 0


### PR DESCRIPTION
## 対応内容

- JigASTにImportFromを追加
- ImportModuleCollectionを拡張
  - len(), in でのモジュール含まれているかどうかの判定追加
  - ImportModuleCollection同士の和集合演算追加
  - AST（Import, ImportFrom ）からコレクション生成するファクトリメソッドを追加
- SourceCodeASTでimport, from import両方からインポート情報を収集するように修正
- main.py コマンドでプロジェクトルートパスをセットしてcollectorを実行するように変更