### PR TITLE
モジュール依存性をdot形式で出力するVisualizerを追加

### DIFF
--- a/jig/visualizer/application/__init__.py
+++ b/jig/visualizer/application/__init__.py
@@ -1,3 +1,4 @@
+import textwrap
 from typing import List
 
 from jig.collector.domain import SourceCode
@@ -16,3 +17,40 @@ class DependencyTextVisualizer:
                 result.append(f"{dep[0]} -> {dep[1]}")
 
         return "\n".join(result)
+
+
+class DotTextVisualizer:
+    def __init__(self, source_codes: List[SourceCode], module_names: List[str]):
+        self._source_codes = source_codes
+        self._module_names = module_names
+
+    # SourceCodeのmodule_dependenciesで返るオブジェクトがTuple[str, str] と貧弱なので
+    # とりあえずモジュールパスを扱えるクラスを仮で実装
+    class ModuleNode:
+        def __init__(self, module_path: str):
+            self.module_path = module_path
+
+        def path(self, level: int) -> str:
+            path_list = self.module_path.split(".")
+            return ".".join(path_list[:level])
+
+    def visualize(self, level: int) -> str:
+        result = []
+        for source_code in self._source_codes:
+            for dep in source_code.module_dependencies(module_names=self._module_names):
+                path1 = self.ModuleNode(module_path=dep[0]).path(level=level)
+                path2 = self.ModuleNode(module_path=dep[1]).path(level=level)
+
+                # 自己参照は依存関係分析的には意味ないので除く
+                if path1 == path2:
+                    continue
+
+                result.append(f'"{path1}" -> "{path2}";')
+
+        # 重複削除とソート
+        edges = sorted(list(set(result)))
+        edge_text = "\n".join(edges)
+
+        graph_text = ["digraph {", textwrap.indent(edge_text, "  "), "}"]
+
+        return "\n".join(graph_text)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from jig.collector.application import SourceCodeCollector
-from jig.visualizer.application import DependencyTextVisualizer
+from jig.visualizer.application import DotTextVisualizer
 
 
 def main():
@@ -12,14 +12,21 @@ def main():
     source_codes = SourceCodeCollector(root_path=root_path).collect(
         target_path=sys.argv[1]
     )
-    print(source_codes)
+    # print(source_codes)
 
     # print(.module_dependencies(["jig"]))
-    print(
-        DependencyTextVisualizer(
-            source_codes=source_codes, module_names=["jig"]
-        ).visualize()
-    )
+    # print(
+    #     DependencyTextVisualizer(
+    #         source_codes=source_codes, module_names=["jig"]
+    #     ).visualize()
+    # )
+
+    dot = DotTextVisualizer(source_codes=source_codes, module_names=["jig"])
+
+    # 環境変数でlevelをもらう（CLI整備するまでの暫定）
+    level = int(os.environ.get("level", 3))
+
+    print(dot.visualize(level=level))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

相談してた構造に変更する前に、ひとまず可視化できるようにしてみることにしました。
（変更後の構造がよいかを見れるように）

実際やってみるとcollectorのドメインにvisualizerが依存してるのが一目で分かる。

## 出力例

コマンド例
```
level=2 python main.py jig/ | dot -Tpng -olevel2.png
```

level 2
![image](https://user-images.githubusercontent.com/1888342/83963692-da7e3180-a8e2-11ea-94c8-f22fa136ba7f.png)

level 3
![image](https://user-images.githubusercontent.com/1888342/83963711-f41f7900-a8e2-11ea-96f3-d6869a62e4ff.png)

level 4
![image](https://user-images.githubusercontent.com/1888342/83963715-fa155a00-a8e2-11ea-87b8-330aa56303a4.png)



level 5
![image](https://user-images.githubusercontent.com/1888342/83963721-000b3b00-a8e3-11ea-87a6-3c32757a928a.png)
