### PR TITLE
モジュール依存関係をpng画像で出力するVisualizerを追加

### DIFF
--- a/jig/visualizer/application/__init__.py
+++ b/jig/visualizer/application/__init__.py
@@ -1,3 +1,4 @@
+import subprocess
 import textwrap
 from typing import List
 
@@ -54,3 +55,19 @@ class DotTextVisualizer:
         graph_text = ["digraph {", textwrap.indent(edge_text, "  "), "}"]
 
         return "\n".join(graph_text)
+
+
+class DependencyImageVisualizer:
+    def __init__(self, source_codes: List[SourceCode], module_names: List[str]):
+        self._dot_text_visualizer = DotTextVisualizer(
+            source_codes=source_codes, module_names=module_names
+        )
+
+    def visualize(self, depth: int) -> None:
+        dot = self._dot_text_visualizer.visualize(depth)
+
+        p = subprocess.Popen(
+            ["dot", "-Tpng", f"-odependency{depth}.png"], stdin=subprocess.PIPE
+        )
+
+        p.communicate(dot.encode())

--- a/main.py
+++ b/main.py
@@ -5,7 +5,11 @@ import fire
 
 from jig.collector.application import SourceCodeCollector
 from jig.collector.domain import SourceCode
-from jig.visualizer.application import DotTextVisualizer, DependencyTextVisualizer
+from jig.visualizer.application import (
+    DotTextVisualizer,
+    DependencyTextVisualizer,
+    DependencyImageVisualizer,
+)
 
 # とりあえずこのmain.pyファイルのパスをルートとする
 ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
@@ -51,6 +55,19 @@ class Main:
         dot = DotTextVisualizer(source_codes=source_codes, module_names=["jig"])
 
         print(dot.visualize(depth=depth))
+
+    def module_dependency(self, target_path: str, depth: int = 3) -> None:
+        """
+        指定されたパスのPythonソースコードを解析し、モジュール依存関係をpng形式の画像として出力します。
+        ディレクトリを指定した場合はそのディレクトリ配下のPythonファイルを再帰的に収集して解析します。
+        :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param depth: モジュールパスのどの深さ（ドットの数）まででグルーピングするかを指定します。（デフォルト=3）
+        :return:
+        """
+        source_codes = self._collect_source_codes(target_path)
+        dot = DependencyImageVisualizer(source_codes=source_codes, module_names=["jig"])
+
+        dot.visualize(depth=depth)
 
     def _collect_source_codes(self, target_path: str) -> List[SourceCode]:
         return list(


### PR DESCRIPTION
Graphvizがインストールされている（dotコマンドが使える）前提。
ファイル名は固定で `dependency{depth}.png` で出力される。