### PR TITLE
ソースコードのルートパス、分析対象のモジュールを指定できるように修正

### DIFF
--- a/jig/collector/application/__init__.py
+++ b/jig/collector/application/__init__.py
@@ -12,24 +12,28 @@ class SourceCodeCollector:
     root_path: str
 
     def collect(self, target_path: str) -> SourceCodeCollection:
-        file_path = FilePath(root_path=self.root_path, relative_path=target_path)
+        rel_path = os.path.relpath(target_path, self.root_path)
+        file_path = FilePath(root_path=self.root_path, relative_path=rel_path)
 
         source_codes = []
         if os.path.isdir(file_path.abspath):
-            source_codes.extend(self.collect_directory(target_path))
+            source_codes.extend(self.collect_directory(rel_path))
         else:
-            source_codes.append(self.collect_file(target_path))
+            source_codes.append(self.collect_file(rel_path))
 
         return SourceCodeCollection(source_codes)
 
     def collect_file(self, target_path: str) -> SourceCode:
-        source = open(target_path).read()
+        # target_pathはrelative_pathを想定しているが、カレントディレクトリからではなく
+        # root_pathからの相対ディレクトリが渡ってくるため、ファイルにアクセスするには一度絶対パスに戻す必要がある
+        abs_path = os.path.join(self.root_path, target_path)
+        source = open(abs_path).read()
 
         return SourceCode.build(
             file=SourceFile(
                 path=FilePath(root_path=self.root_path, relative_path=target_path),
                 content=source,
-                size=os.path.getsize(target_path),
+                size=os.path.getsize(abs_path),
             ),
         )
 
@@ -41,9 +45,11 @@ class SourceCodeCollector:
             for file in files:
                 if not file.endswith(".py"):
                     continue
+
                 path = FilePath.build_with_abspath(
                     root_path=self.root_path, abspath=os.path.join(cur_dir, file)
                 )
+
                 result.append(self.collect_file(target_path=path.relative_path))
 
         return result

--- a/jig/collector/domain/__init__.py
+++ b/jig/collector/domain/__init__.py
@@ -169,6 +169,12 @@ class SourceCode:
         )
 
     def module_dependencies(self, module_names: List[str]) -> List[Tuple[str, str]]:
+        if not module_names:
+            return [
+                (self.module_path.path, module.module_path.path)
+                for module in self.import_modules
+            ]
+
         dependencies = []
         for module in self.import_modules:
             if module.module_path.match_module_names(module_names):

--- a/main.py
+++ b/main.py
@@ -28,7 +28,10 @@ class Main:
         print(source_codes)
 
     def dependency_text(
-        self, target_path: str, root_path: Optional[str] = None
+        self,
+        target_path: str,
+        root_path: Optional[str] = None,
+        module_names: List[str] = None,
     ) -> None:
         """
         指定されたパスのPythonソースコードを解析し、モジュール依存関係を表示します。
@@ -36,6 +39,9 @@ class Main:
         収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
         :param root_path: 解析対象Pythonコードのルートディレクトリパス
+        :param module_names: 出力結果に含めるモジュールのパスプレフィックス。"jig"を指定した場合、"jig.xxx.yyy" といった
+                             モジュールだけが結果に含まれるようになります。複数指定したい場合は配列形式で指定します。
+                             （例: --module_names "[jig, os]"）
         :return:
         """
         source_codes = self._collect_source_codes(
@@ -43,12 +49,16 @@ class Main:
         )
         print(
             DependencyTextVisualizer(
-                source_codes=source_codes, module_names=["jig"]
+                source_codes=source_codes, module_names=module_names or []
             ).visualize()
         )
 
     def dot_text(
-        self, target_path: str, root_path: Optional[str] = None, depth: int = 3
+        self,
+        target_path: str,
+        root_path: Optional[str] = None,
+        module_names: List[str] = None,
+        depth: int = 3,
     ) -> None:
         """
         指定されたパスのPythonソースコードを解析し、モジュール依存関係をdot形式で出力します。
@@ -56,13 +66,18 @@ class Main:
         収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
         :param root_path: 解析対象Pythonコードのルートディレクトリパス
+        :param module_names: 出力結果に含めるモジュールのパスプレフィックス。"jig"を指定した場合、"jig.xxx.yyy" といった
+                             モジュールだけが結果に含まれるようになります。複数指定したい場合は配列形式で指定します。
+                             （例: --module_names "[jig, os]"）
         :param depth: モジュールパスのどの深さ（ドットの数）まででグルーピングするかを指定します。（デフォルト=3）
         :return:
         """
         source_codes = self._collect_source_codes(
             target_path=target_path, root_path=root_path
         )
-        dot = DotTextVisualizer(source_codes=source_codes, module_names=["jig"])
+        dot = DotTextVisualizer(
+            source_codes=source_codes, module_names=module_names or []
+        )
 
         print(dot.visualize(depth=depth))
 
@@ -70,6 +85,7 @@ class Main:
         self,
         target_path: str,
         root_path: Optional[str] = None,
+        module_names: List[str] = None,
         depth: int = 3,
         output_dir: str = "./output",
     ) -> None:
@@ -78,14 +94,22 @@ class Main:
         ディレクトリを指定した場合はそのディレクトリ配下のPythonファイルを再帰的に収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
         :param root_path: 解析対象Pythonコードのルートディレクトリパス（デフォルト=実行時のカレントディレクトリ）
+        :param module_names: 出力結果に含めるモジュールのパスプレフィックス。"jig"を指定した場合、"jig.xxx.yyy" といった
+                             モジュールだけが結果に含まれるようになります。複数指定したい場合は配列形式で指定します。
+                             （例: --module_names "[jig, os]"）
         :param depth: モジュールパスのどの深さ（ドットの数）まででグルーピングするかを指定します。（デフォルト=3）
         :param output_dir: 出力先ディレクトリ。（デフォルト=./output）
         :return:
         """
+        if isinstance(module_names, str):
+            module_names = [module_names]
+
         source_codes = self._collect_source_codes(
             target_path=target_path, root_path=root_path
         )
-        dot = DependencyImageVisualizer(source_codes=source_codes, module_names=["jig"])
+        dot = DependencyImageVisualizer(
+            source_codes=source_codes, module_names=module_names or []
+        )
 
         dot.visualize(depth=depth, output_dir=output_dir)
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Optional
 
 import fire
 
@@ -11,70 +11,94 @@ from jig.visualizer.application import (
     DependencyImageVisualizer,
 )
 
-# とりあえずこのmain.pyファイルのパスをルートとする
-ROOT_PATH = os.path.dirname(os.path.abspath(__file__))
-
 
 class Main:
-    def source_codes(self, target_path: str) -> None:
+    def source_codes(self, target_path: str, root_path: Optional[str] = None) -> None:
         """
         指定されたパスのPythonソースコード解析結果を表示します。
         ディレクトリを指定した場合は再帰的にPythonファイルを収集し、全てのソースコード
         解析結果を表示します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス
         :return:
         """
-        source_codes = self._collect_source_codes(target_path)
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
         print(source_codes)
 
-    def dependency_text(self, target_path: str) -> None:
+    def dependency_text(
+        self, target_path: str, root_path: Optional[str] = None
+    ) -> None:
         """
         指定されたパスのPythonソースコードを解析し、モジュール依存関係を表示します。
         ディレクトリを指定した場合はそのディレクトリ配下のPythonファイルを再帰的に
         収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス
         :return:
         """
-        source_codes = self._collect_source_codes(target_path)
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
         print(
             DependencyTextVisualizer(
                 source_codes=source_codes, module_names=["jig"]
             ).visualize()
         )
 
-    def dot_text(self, target_path: str, depth: int = 3) -> None:
+    def dot_text(
+        self, target_path: str, root_path: Optional[str] = None, depth: int = 3
+    ) -> None:
         """
         指定されたパスのPythonソースコードを解析し、モジュール依存関係をdot形式で出力します。
         ディレクトリを指定した場合はそのディレクトリ配下のPythonファイルを再帰的に
         収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス
         :param depth: モジュールパスのどの深さ（ドットの数）まででグルーピングするかを指定します。（デフォルト=3）
         :return:
         """
-        source_codes = self._collect_source_codes(target_path)
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
         dot = DotTextVisualizer(source_codes=source_codes, module_names=["jig"])
 
         print(dot.visualize(depth=depth))
 
     def module_dependency(
-        self, target_path: str, depth: int = 3, output_dir: str = "./output"
+        self,
+        target_path: str,
+        root_path: Optional[str] = None,
+        depth: int = 3,
+        output_dir: str = "./output",
     ) -> None:
         """
         指定されたパスのPythonソースコードを解析し、モジュール依存関係をpng形式の画像として出力します。
         ディレクトリを指定した場合はそのディレクトリ配下のPythonファイルを再帰的に収集して解析します。
         :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス（デフォルト=実行時のカレントディレクトリ）
         :param depth: モジュールパスのどの深さ（ドットの数）まででグルーピングするかを指定します。（デフォルト=3）
         :param output_dir: 出力先ディレクトリ。（デフォルト=./output）
         :return:
         """
-        source_codes = self._collect_source_codes(target_path)
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
         dot = DependencyImageVisualizer(source_codes=source_codes, module_names=["jig"])
 
         dot.visualize(depth=depth, output_dir=output_dir)
 
-    def _collect_source_codes(self, target_path: str) -> List[SourceCode]:
+    def _collect_source_codes(
+        self, target_path: str, root_path: Optional[str]
+    ) -> List[SourceCode]:
+        if not root_path:
+            root_path = os.getcwd()
+
+        root_path = os.path.abspath(root_path)
+
         return list(
-            SourceCodeCollector(root_path=ROOT_PATH).collect(target_path=target_path)
+            SourceCodeCollector(root_path=root_path).collect(target_path=target_path)
         )
 
 

--- a/tests/collector/end_to_end/test_jig_py_20200609.py
+++ b/tests/collector/end_to_end/test_jig_py_20200609.py
@@ -51,6 +51,7 @@ class TestJigPy20200609:
         assert cls.get_code_path() is not None
 
     def test_collector(self):
+        os.chdir(self.get_code_path())
         source_code_collection = SourceCodeCollector(
             root_path=self.get_code_path()
         ).collect("jig")
@@ -113,7 +114,6 @@ class TestJigPy20200609:
                 ImportModule(ModulePath("os")),
                 ImportModule(ModulePath("typing.List")),
                 ImportModule(ModulePath("jig.collector.domain.FilePath")),
-                ImportModule(ModulePath("jig.collector.domain.SourceCodeCollection")),
                 ImportModule(ModulePath("jig.collector.domain.SourceCode")),
                 ImportModule(ModulePath("jig.collector.domain.SourceFile")),
             ]


### PR DESCRIPTION
jig-py以外のソースコードを分析できるように、ルートパス、フィルタするモジュールをコマンド引数として指定できるように修正。

相対パスで指定する例

```
python main.py module_dependency ../balus-tng/server/src --root_path ../balus-tng/server/src --module_names feedback --depth 2
```

出力結果
![image](https://user-images.githubusercontent.com/1888342/84592871-b17e1380-ae83-11ea-808e-0589165d345a.png)