### PR TITLE
jig-pyコマンドを配布できる形式に整備

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -17,7 +17,7 @@ jobs:
         pip install mypy lxml
     - name: Lint with mypy
       run: |
-        mypy main.py jig
+        mypy jig
     - uses: actions/upload-artifact@master
       if: always()
       with:
@@ -38,7 +38,7 @@ jobs:
           pip install black
       - name: Lint with black
         run: |
-          black --diff --check main.py jig/ tests/
+          black --diff --check jig/ tests/
 
   flake8:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
           pip install flake8
       - name: Lint with flake8
         run: |
-          flake8 main.py jig/ tests/
+          flake8 jig/ tests/
 
   pytest:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,15 @@ clean:
 
 .PHONY: mypy
 mypy:
-	${server_runner} mypy main.py jig/
+	${server_runner} mypy jig/
 
 .PHONY: black
 black:
-	${server_runner} black main.py jig/ tests/
+	${server_runner} black jig/ tests/
 
 .PHONY: flake8
 flake8:
-	${server_runner} flake8 main.py jig/ tests/
+	${server_runner} flake8 jig/ tests/
 
 .PHONY: check
 check: mypy black flake8

--- a/jig/cli/main.py
+++ b/jig/cli/main.py
@@ -1,13 +1,13 @@
 import os
-from typing import List, Optional
+from typing import Optional, List
 
 import fire
 
 from jig.collector.application import SourceCodeCollector
 from jig.collector.domain import SourceCode
 from jig.visualizer.application import (
-    DotTextVisualizer,
     DependencyTextVisualizer,
+    DotTextVisualizer,
     DependencyImageVisualizer,
 )
 
@@ -126,5 +126,9 @@ class Main:
         )
 
 
-if __name__ == "__main__":
+def main():
     fire.Fire(Main)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 
 name = "jig-py"
-version = "0.0.1"
+version = "0.0.2a0"
 description = "Jig for Python"
 dependencies = []
 
@@ -26,6 +26,7 @@ setuptools.setup(
     url="https://github.com/levii/jig-py",
     packages=packages,
     namespaces=namespaces,
+    entry_points={"console_scripts": ["jig-py = jig.cli.main:main"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
pip install で `jig-py` コマンドが利用できるように整備。
ローカルでは動作確認済み。パブリッシュはまだ。

バージョンはひとまず `0.0.2a0` としています。