### PR TITLE
ファイルパスとモジュールパス周りを標準ライブラリのpathlibを使った形にリファクタリング

### DIFF
--- a/jig/cli/main.py
+++ b/jig/cli/main.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Optional, List
 
 import fire
@@ -119,10 +120,10 @@ class Main:
         if not root_path:
             root_path = os.getcwd()
 
-        root_path = os.path.abspath(root_path)
-
         return list(
-            SourceCodeCollector(root_path=root_path).collect(target_path=target_path)
+            SourceCodeCollector(root_path=Path(root_path)).collect(
+                target_path=Path(target_path)
+            )
         )
 
 

--- a/jig/collector/application/__init__.py
+++ b/jig/collector/application/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
 import os
+from pathlib import Path
 from typing import List
 
 from jig.collector.domain import FilePath, SourceCodeCollection
@@ -9,47 +10,42 @@ from jig.collector.domain import SourceFile
 
 @dataclasses.dataclass(frozen=True)
 class SourceCodeCollector:
-    root_path: str
+    root_path: Path
 
-    def collect(self, target_path: str) -> SourceCodeCollection:
-        rel_path = os.path.relpath(target_path, self.root_path)
-        file_path = FilePath(root_path=self.root_path, relative_path=rel_path)
-
+    def collect(self, target_path: Path) -> SourceCodeCollection:
         source_codes = []
-        if os.path.isdir(file_path.abspath):
-            source_codes.extend(self.collect_directory(rel_path))
+        if target_path.is_dir():
+            source_codes.extend(self.collect_directory(target_path))
         else:
-            source_codes.append(self.collect_file(rel_path))
+            source_codes.append(self.collect_file(target_path))
 
         return SourceCodeCollection(source_codes)
 
-    def collect_file(self, target_path: str) -> SourceCode:
-        # target_pathはrelative_pathを想定しているが、カレントディレクトリからではなく
-        # root_pathからの相対ディレクトリが渡ってくるため、ファイルにアクセスするには一度絶対パスに戻す必要がある
-        abs_path = os.path.join(self.root_path, target_path)
-        source = open(abs_path).read()
+    def collect_file(self, target_path: Path) -> SourceCode:
+        source = target_path.read_text()
+        relative_path = str(
+            target_path.absolute().relative_to(self.root_path.absolute())
+        )
 
         return SourceCode.build(
             file=SourceFile(
-                path=FilePath(root_path=self.root_path, relative_path=target_path),
+                path=FilePath(
+                    root_path=str(self.root_path), relative_path=relative_path
+                ),
                 content=source,
-                size=os.path.getsize(abs_path),
+                size=os.path.getsize(str(target_path)),
             ),
         )
 
-    def collect_directory(self, target_path: str) -> List[SourceCode]:
-        file_path = FilePath(root_path=self.root_path, relative_path=target_path)
-
+    def collect_directory(self, target_path: Path) -> List[SourceCode]:
         result = []
-        for cur_dir, dirs, files in os.walk(file_path.abspath):
+        for cur_dir, dirs, files in os.walk(str(target_path)):
             for file in files:
                 if not file.endswith(".py"):
                     continue
 
-                path = FilePath.build_with_abspath(
-                    root_path=self.root_path, abspath=os.path.join(cur_dir, file)
-                )
+                path = Path(cur_dir).joinpath(file)
 
-                result.append(self.collect_file(target_path=path.relative_path))
+                result.append(self.collect_file(target_path=path))
 
         return result

--- a/jig/collector/application/__init__.py
+++ b/jig/collector/application/__init__.py
@@ -3,9 +3,12 @@ import os
 from pathlib import Path
 from typing import List
 
-from jig.collector.domain import FilePath, SourceCodeCollection
-from jig.collector.domain import SourceCode
-from jig.collector.domain import SourceFile
+from jig.collector.domain import (
+    SourceCode,
+    SourceCodeCollection,
+    SourceFile,
+    SourceFilePath,
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -23,14 +26,11 @@ class SourceCodeCollector:
 
     def collect_file(self, target_path: Path) -> SourceCode:
         source = target_path.read_text()
-        relative_path = str(
-            target_path.absolute().relative_to(self.root_path.absolute())
-        )
 
         return SourceCode.build(
             file=SourceFile(
-                path=FilePath(
-                    root_path=str(self.root_path), relative_path=relative_path
+                source_file_path=SourceFilePath(
+                    root_path=self.root_path, file_path=target_path
                 ),
                 content=source,
                 size=os.path.getsize(str(target_path)),

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -1,66 +1,71 @@
-from jig.collector.domain import FilePath
-from jig.collector.domain import ImportModule, ModulePath, ImportModuleCollection
+from pathlib import Path
+
+from jig.collector.domain import SourceFilePath, ModulePath
+from jig.collector.domain import ImportModule, ImportModuleCollection
 from .helper import parse_import_from
 
 
 class TestImportModuleCollectionBuildByImportFromAST:
     ROOT_PATH = "/jig-py"
     CURRENT_PATH = "/jig-py/jig/collector/domain/__init__.py"
-    FILE_PATH = FilePath.build_with_abspath(root_path=ROOT_PATH, abspath=CURRENT_PATH)
+    SOURCE_FILE_PATH = SourceFilePath(
+        root_path=Path(ROOT_PATH), file_path=Path(CURRENT_PATH)
+    )
 
     def test_builtin_module(self):
         import_from = parse_import_from("from os import path")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
-        assert ImportModule(ModulePath("os.path")) in import_modules
+        assert ImportModule(ModulePath.from_str("os.path")) in import_modules
 
     def test_multiple_import_module(self):
         import_from = parse_import_from("from datetime import datetime, timezone")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 2
-        assert ImportModule(ModulePath("datetime.datetime")) in import_modules
-        assert ImportModule(ModulePath("datetime.timezone")) in import_modules
+        assert ImportModule(ModulePath.from_str("datetime.datetime")) in import_modules
+        assert ImportModule(ModulePath.from_str("datetime.timezone")) in import_modules
 
     def test_external_module(self):
         import_from = parse_import_from("from typed_ast import ast3 as ast")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
-        assert ImportModule(ModulePath("typed_ast.ast3")) in import_modules
+        assert ImportModule(ModulePath.from_str("typed_ast.ast3")) in import_modules
 
     def test_import_from_current_path(self):
         import_from = parse_import_from("from . import sibling")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
         assert (
-            ImportModule(ModulePath("jig.collector.domain.sibling")) in import_modules
+            ImportModule(ModulePath.from_str("jig.collector.domain.sibling"))
+            in import_modules
         )
 
     def test_import_from_current_path_with_module_name(self):
         import_from = parse_import_from("from .sibling import submodule")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
         assert (
-            ImportModule(ModulePath("jig.collector.domain.sibling.submodule"))
+            ImportModule(ModulePath.from_str("jig.collector.domain.sibling.submodule"))
             in import_modules
         )
 
@@ -68,21 +73,23 @@ class TestImportModuleCollectionBuildByImportFromAST:
         import_from = parse_import_from("from .. import jig_ast")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
-        assert ImportModule(ModulePath("jig.collector.jig_ast")) in import_modules
+        assert (
+            ImportModule(ModulePath.from_str("jig.collector.jig_ast")) in import_modules
+        )
 
     def test_import_from_parent_path_with_module_name(self):
         import_from = parse_import_from("from ..jig_ast import submodule")
 
         import_modules = ImportModuleCollection.build_by_import_from_ast(
-            file_path=self.FILE_PATH, import_from=import_from
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
         assert len(import_modules) == 1
         assert (
-            ImportModule(ModulePath("jig.collector.jig_ast.submodule"))
+            ImportModule(ModulePath.from_str("jig.collector.jig_ast.submodule"))
             in import_modules
         )

--- a/tests/collector/domain/test_module_path.py
+++ b/tests/collector/domain/test_module_path.py
@@ -1,17 +1,19 @@
-from jig.collector.domain import FilePath, ModulePath
+from jig.collector.domain import ModulePath
+
+
+def mod(path: str) -> ModulePath:
+    return ModulePath.from_str(path)
 
 
 class TestModulePath:
-    def test_build_by_file_path(self):
-        path = FilePath(root_path="/root", relative_path="path/to/file.py")
-        module_path = ModulePath.build_by_file_path(path)
+    def test_from_str(self):
+        p = ModulePath(names=["jig", "collector", "domain"])
+        assert p == ModulePath.from_str("jig.collector.domain")
 
-        assert isinstance(module_path, ModulePath)
-        assert module_path.path == "path.to.file"
+    def test_str(self):
+        p = mod("jig.collector.domain")
+        assert str(p) == "jig.collector.domain"
 
-    def test_build_by_file_path_init(self):
-        path = FilePath(root_path="/root", relative_path="path/to/package/__init__.py")
-        module_path = ModulePath.build_by_file_path(path)
-
-        assert isinstance(module_path, ModulePath)
-        assert module_path.path == "path.to.package"
+    def test_join(self):
+        p = mod("jig.collector.domain")
+        assert p.join("mod") == mod("jig.collector.domain.mod")

--- a/tests/collector/domain/test_source_code_ast.py
+++ b/tests/collector/domain/test_source_code_ast.py
@@ -1,15 +1,17 @@
-from jig.collector.domain import FilePath
-from jig.collector.domain import SourceCode
+from pathlib import Path
+
 from jig.collector.domain import (
     SourceFile,
+    SourceFilePath,
     ModulePath,
     ImportModule,
     ImportModuleCollection,
+    SourceCode,
 )
 
 
 def collection(*args):
-    modules = [ImportModule(ModulePath(p)) for p in args]
+    modules = [ImportModule(ModulePath.from_str(p)) for p in args]
 
     return ImportModuleCollection(modules)
 
@@ -17,14 +19,18 @@ def collection(*args):
 class TestSourceCodeASTGetImports:
     ROOT_PATH = "/jig-py"
     SOURCE_PATH = "/jig-py/jig/collector/domain/__init__.py"
-    FILE_PATH = FilePath.build_with_abspath(root_path=ROOT_PATH, abspath=SOURCE_PATH)
+    SOURCE_FILE_PATH = SourceFilePath(
+        root_path=Path(ROOT_PATH), file_path=Path(SOURCE_PATH)
+    )
 
     def test_multiple_modules(self):
         content = """
 import os, datetime
         """
 
-        file = SourceFile(path=self.FILE_PATH, content=content, size=len(content))
+        file = SourceFile(
+            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+        )
         ast = SourceCode.build(file)
 
         assert ast.import_modules == collection("os", "datetime")
@@ -35,7 +41,9 @@ import os
 import datetime as dt
         """
 
-        file = SourceFile(path=self.FILE_PATH, content=content, size=len(content))
+        file = SourceFile(
+            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+        )
         ast = SourceCode.build(file)
 
         assert ast.import_modules == collection("os", "datetime")
@@ -45,7 +53,9 @@ import datetime as dt
 from os import path
         """
 
-        file = SourceFile(path=self.FILE_PATH, content=content, size=len(content))
+        file = SourceFile(
+            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+        )
         ast = SourceCode.build(file)
 
         assert ast.import_modules == collection("os.path")
@@ -59,7 +69,9 @@ from . import submodule
 from .. import jig_ast
         """
 
-        file = SourceFile(path=self.FILE_PATH, content=content, size=len(content))
+        file = SourceFile(
+            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+        )
         ast = SourceCode.build(file)
 
         modules = [

--- a/tests/collector/domain/test_source_file.py
+++ b/tests/collector/domain/test_source_file.py
@@ -1,11 +1,15 @@
-from jig.collector.domain import FilePath
+from pathlib import Path
+
+from jig.collector.domain import SourceFilePath
 from jig.collector.domain import SourceFile
 
 
 class TestSourceFile:
     def test_build(self):
         source_file = SourceFile(
-            path=FilePath(root_path="/root", relative_path="path/to/file.py"),
+            source_file_path=SourceFilePath(
+                root_path=Path("/root"), file_path=Path("path/to/file.py")
+            ),
             size=123,
             content="this is content",
         )

--- a/tests/collector/end_to_end/test_jig_py_20200609.py
+++ b/tests/collector/end_to_end/test_jig_py_20200609.py
@@ -58,7 +58,10 @@ class TestJigPy20200609:
         ).collect(Path("jig"))
         assert len(source_code_collection) == 10
         filenames = sorted(
-            [code.file.path.relative_path for code in source_code_collection]
+            [
+                str(code.file.source_file_path.relative_path_from_root)
+                for code in source_code_collection
+            ]
         )
         assert filenames == [
             "jig/__init__.py",
@@ -75,47 +78,59 @@ class TestJigPy20200609:
 
         jig_init_py = source_code_collection.get_by_relative_path("jig/__init__.py")
         assert jig_init_py.file.content == ""
-        assert jig_init_py.module_path == ModulePath("jig")
+        assert jig_init_py.module_path == ModulePath.from_str("jig")
         assert jig_init_py.import_modules == ImportModuleCollection([])
         assert jig_init_py.class_defs == []
 
         jig_collector_jig_ast_init = source_code_collection.get_by_relative_path(
             "jig/collector/jig_ast/__init__.py"
         )
-        assert jig_collector_jig_ast_init.module_path == ModulePath(
+        assert jig_collector_jig_ast_init.module_path == ModulePath.from_str(
             "jig.collector.jig_ast"
         )
         assert jig_collector_jig_ast_init.import_modules == ImportModuleCollection(
             [
-                ImportModule(ModulePath("dataclasses")),
-                ImportModule(ModulePath("typed_ast.ast3")),
-                ImportModule(ModulePath("typing.List")),
-                ImportModule(ModulePath("jig.collector.jig_ast.class_def.ClassDef")),
+                ImportModule(ModulePath.from_str("dataclasses")),
+                ImportModule(ModulePath.from_str("typed_ast.ast3")),
+                ImportModule(ModulePath.from_str("typing.List")),
                 ImportModule(
-                    ModulePath("jig.collector.jig_ast.class_def.ClassDefVisitor")
+                    ModulePath.from_str("jig.collector.jig_ast.class_def.ClassDef")
                 ),
-                ImportModule(ModulePath("jig.collector.jig_ast.imports.Import")),
-                ImportModule(ModulePath("jig.collector.jig_ast.imports.ImportFrom")),
                 ImportModule(
-                    ModulePath("jig.collector.jig_ast.imports.ImportFromVisitor")
+                    ModulePath.from_str(
+                        "jig.collector.jig_ast.class_def.ClassDefVisitor"
+                    )
                 ),
-                ImportModule(ModulePath("jig.collector.jig_ast.imports.ImportVisitor")),
+                ImportModule(
+                    ModulePath.from_str("jig.collector.jig_ast.imports.Import")
+                ),
+                ImportModule(
+                    ModulePath.from_str("jig.collector.jig_ast.imports.ImportFrom")
+                ),
+                ImportModule(
+                    ModulePath.from_str(
+                        "jig.collector.jig_ast.imports.ImportFromVisitor"
+                    )
+                ),
+                ImportModule(
+                    ModulePath.from_str("jig.collector.jig_ast.imports.ImportVisitor")
+                ),
             ]
         )
 
         jig_collector_application = source_code_collection.get_by_relative_path(
             "jig/collector/application/__init__.py"
         )
-        assert jig_collector_application.module_path == ModulePath(
+        assert jig_collector_application.module_path == ModulePath.from_str(
             "jig.collector.application"
         )
         assert jig_collector_application.import_modules == ImportModuleCollection(
             [
-                ImportModule(ModulePath("dataclasses")),
-                ImportModule(ModulePath("os")),
-                ImportModule(ModulePath("typing.List")),
-                ImportModule(ModulePath("jig.collector.domain.FilePath")),
-                ImportModule(ModulePath("jig.collector.domain.SourceCode")),
-                ImportModule(ModulePath("jig.collector.domain.SourceFile")),
+                ImportModule(ModulePath.from_str("dataclasses")),
+                ImportModule(ModulePath.from_str("os")),
+                ImportModule(ModulePath.from_str("typing.List")),
+                ImportModule(ModulePath.from_str("jig.collector.domain.FilePath")),
+                ImportModule(ModulePath.from_str("jig.collector.domain.SourceCode")),
+                ImportModule(ModulePath.from_str("jig.collector.domain.SourceFile")),
             ]
         )

--- a/tests/collector/end_to_end/test_jig_py_20200609.py
+++ b/tests/collector/end_to_end/test_jig_py_20200609.py
@@ -2,6 +2,7 @@ import os
 import urllib.request
 import zipfile
 import io
+from pathlib import Path
 from typing import Optional
 
 from jig.collector.application import SourceCodeCollector
@@ -53,8 +54,8 @@ class TestJigPy20200609:
     def test_collector(self):
         os.chdir(self.get_code_path())
         source_code_collection = SourceCodeCollector(
-            root_path=self.get_code_path()
-        ).collect("jig")
+            root_path=Path(self.get_code_path())
+        ).collect(Path("jig"))
         assert len(source_code_collection) == 10
         filenames = sorted(
             [code.file.path.relative_path for code in source_code_collection]


### PR DESCRIPTION
FilePath ちょっと一般的すぎるのでソースコードのファイルとパスの意味でSourceFilePathにリネームしました。