### PR TITLE
importのパース時にエラーになっていた問題を修正

### DIFF
--- a/jig/collector/domain/__init__.py
+++ b/jig/collector/domain/__init__.py
@@ -143,7 +143,7 @@ class ImportModuleCollection:
     @classmethod
     def build_by_import_ast(cls, import_ast: Import) -> "ImportModuleCollection":
         imports = [
-            ImportModule(module_path=ModulePath(names=[name.name]))
+            ImportModule(module_path=ModulePath.from_str(name.name))
             for name in import_ast.names
         ]
 

--- a/jig/collector/domain/__init__.py
+++ b/jig/collector/domain/__init__.py
@@ -12,7 +12,11 @@ class ModulePath:
     names: List[str]
 
     def __post_init__(self):
-        assert any([name.find(".") < 0 for name in self.names])
+        if any([name.find(".") >= 0 for name in self.names]):
+            raise ValueError(f"An invalid name specified in `{self.names}`")
+
+    def __add__(self, other: "ModulePath") -> "ModulePath":
+        return ModulePath(names=self.names + other.names)
 
     def join(self, name: str) -> "ModulePath":
         """
@@ -98,7 +102,7 @@ class SourceFilePath:
         p = self.module_path_with_level(level)
 
         if import_from.module:
-            p = p.join(import_from.module)
+            p += ModulePath.from_str(import_from.module)
 
         return [p.join(alias.name) for alias in import_from.names]
 

--- a/jig/collector/domain/ast/__init__.py
+++ b/jig/collector/domain/ast/__init__.py
@@ -21,6 +21,15 @@ class Import:
     names: List[Alias]
     _ast: ast.Import = dataclasses.field(repr=False, compare=False)
 
+    @classmethod
+    def from_ast(cls, import_ast: ast.Import) -> "Import":
+        names = [
+            Alias(name=name_alias.name, asname=name_alias.asname)
+            for name_alias in import_ast.names
+        ]
+
+        return cls(names=names, _ast=import_ast)
+
 
 @dataclasses.dataclass(frozen=True)
 class ImportFrom:
@@ -108,15 +117,7 @@ class ImportVisitor(ast.NodeVisitor):
     imports: List[Import] = dataclasses.field(default_factory=list)
 
     def visit_Import(self, node):
-        self.imports.append(
-            Import(
-                names=[
-                    Alias(name=name_alias.name, asname=name_alias.asname)
-                    for name_alias in node.names
-                ],
-                _ast=node,
-            )
-        )
+        self.imports.append(Import.from_ast(node))
 
 
 @dataclasses.dataclass

--- a/tests/collector/domain/helper.py
+++ b/tests/collector/domain/helper.py
@@ -1,5 +1,5 @@
 from typed_ast import ast3 as ast
-from jig.collector.domain.ast import ImportFrom
+from jig.collector.domain.ast import ImportFrom, Import
 
 
 def parse_import_from(line: str) -> ImportFrom:
@@ -8,3 +8,11 @@ def parse_import_from(line: str) -> ImportFrom:
     assert isinstance(import_from_ast, ast.ImportFrom)
 
     return ImportFrom.from_ast(import_from_ast)
+
+
+def parse_import(line: str) -> Import:
+    import_ast = ast.parse(line).body[0]
+
+    assert isinstance(import_ast, ast.Import)
+
+    return Import.from_ast(import_ast)

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -93,3 +93,16 @@ class TestImportModuleCollectionBuildByImportFromAST:
             ImportModule(ModulePath.from_str("jig.collector.jig_ast.submodule"))
             in import_modules
         )
+
+    def test_import_from_nested_module(self):
+        import_from = parse_import_from("from .aaa.bbb import xxx")
+
+        import_modules = ImportModuleCollection.build_by_import_from_ast(
+            file_path=self.SOURCE_FILE_PATH, import_from=import_from
+        )
+
+        assert len(import_modules) == 1
+        assert (
+            ImportModule(ModulePath.from_str("jig.collector.domain.aaa.bbb.xxx"))
+            in import_modules
+        )

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -27,8 +27,7 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert ImportModule(ModulePath.from_str("os.path")) in import_modules
+        assert import_modules == mod_collections("os.path")
 
     def test_multiple_import_module(self):
         import_from = parse_import_from("from datetime import datetime, timezone")
@@ -37,9 +36,9 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 2
-        assert ImportModule(ModulePath.from_str("datetime.datetime")) in import_modules
-        assert ImportModule(ModulePath.from_str("datetime.timezone")) in import_modules
+        assert import_modules == mod_collections(
+            "datetime.datetime", "datetime.timezone"
+        )
 
     def test_external_module(self):
         import_from = parse_import_from("from typed_ast import ast3 as ast")
@@ -48,8 +47,7 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert ImportModule(ModulePath.from_str("typed_ast.ast3")) in import_modules
+        assert import_modules == mod_collections("typed_ast.ast3")
 
     def test_import_from_current_path(self):
         import_from = parse_import_from("from . import sibling")
@@ -58,11 +56,7 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert (
-            ImportModule(ModulePath.from_str("jig.collector.domain.sibling"))
-            in import_modules
-        )
+        assert import_modules == mod_collections("jig.collector.domain.sibling")
 
     def test_import_from_current_path_with_module_name(self):
         import_from = parse_import_from("from .sibling import submodule")
@@ -71,10 +65,8 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert (
-            ImportModule(ModulePath.from_str("jig.collector.domain.sibling.submodule"))
-            in import_modules
+        assert import_modules == mod_collections(
+            "jig.collector.domain.sibling.submodule"
         )
 
     def test_import_from_parent_path(self):
@@ -96,11 +88,7 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert (
-            ImportModule(ModulePath.from_str("jig.collector.jig_ast.submodule"))
-            in import_modules
-        )
+        assert import_modules == mod_collections("jig.collector.jig_ast.submodule")
 
     def test_import_from_nested_module(self):
         import_from = parse_import_from("from .aaa.bbb import xxx")
@@ -109,11 +97,7 @@ class TestImportModuleCollectionBuildByImportFromAST:
             file_path=self.SOURCE_FILE_PATH, import_from=import_from
         )
 
-        assert len(import_modules) == 1
-        assert (
-            ImportModule(ModulePath.from_str("jig.collector.domain.aaa.bbb.xxx"))
-            in import_modules
-        )
+        assert import_modules == mod_collections("jig.collector.domain.aaa.bbb.xxx")
 
 
 class TestImportModuleCollectionBuildByImportAST:

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -2,7 +2,15 @@ from pathlib import Path
 
 from jig.collector.domain import SourceFilePath, ModulePath
 from jig.collector.domain import ImportModule, ImportModuleCollection
-from .helper import parse_import_from
+from .helper import parse_import_from, parse_import
+
+
+def mod_collections(*modules) -> ImportModuleCollection:
+    return ImportModuleCollection(
+        _modules=[
+            ImportModule(module_path=ModulePath.from_str(module)) for module in modules
+        ]
+    )
 
 
 class TestImportModuleCollectionBuildByImportFromAST:
@@ -106,3 +114,23 @@ class TestImportModuleCollectionBuildByImportFromAST:
             ImportModule(ModulePath.from_str("jig.collector.domain.aaa.bbb.xxx"))
             in import_modules
         )
+
+
+class TestImportModuleCollectionBuildByImportAST:
+    def test_one_module(self):
+        import_ast = parse_import("import os")
+
+        import_modules = ImportModuleCollection.build_by_import_ast(import_ast)
+        assert import_modules == mod_collections("os")
+
+    def test_nested_module(self):
+        import_ast = parse_import("import datetime.datetime")
+
+        import_modules = ImportModuleCollection.build_by_import_ast(import_ast)
+        assert import_modules == mod_collections("datetime.datetime")
+
+    def test_multiple_modules(self):
+        import_ast = parse_import("import os, datetime.datetime")
+
+        import_modules = ImportModuleCollection.build_by_import_ast(import_ast)
+        assert import_modules == mod_collections("os", "datetime.datetime")

--- a/tests/collector/domain/test_module_path.py
+++ b/tests/collector/domain/test_module_path.py
@@ -17,3 +17,10 @@ class TestModulePath:
     def test_join(self):
         p = mod("jig.collector.domain")
         assert p.join("mod") == mod("jig.collector.domain.mod")
+
+    def test_add(self):
+        m1 = mod("aaa.bbb")
+        m2 = mod("xxx.yyy")
+
+        assert m1 + m2 == mod("aaa.bbb.xxx.yyy")
+        assert m2 + m1 == mod("xxx.yyy.aaa.bbb")


### PR DESCRIPTION
## 原因

* `import <<module>>`
* `from ..<<module>> import xxxx`

それぞれの `<<module>>` パートにネストされたモジュール名（`aaa.bbb`）が指定された時の考慮漏れ。

ネストされた名前が指定された場合でも正しくModulePathが組み立てられるように修正。