### PR TITLE
ModuleDependencyAnalyzerを追加して、モジュール依存関係の可視化を解析対象ファイル間の依存に限定

### DIFF
--- a/jig/analizer/application/__init__.py
+++ b/jig/analizer/application/__init__.py
@@ -1,0 +1,19 @@
+import dataclasses
+from typing import List
+
+from jig.analizer.domain import SourceCodeList
+from jig.collector.domain import ModuleDependency
+
+
+@dataclasses.dataclass(frozen=True)
+class ModuleDependencyAnalyzer:
+    source_code_list: SourceCodeList
+
+    def analyze(self) -> List[ModuleDependency]:
+        module_space = self.source_code_list.to_module_space()
+
+        return [
+            dep
+            for dep in self.source_code_list.all_dependencies()
+            if module_space.includes(dep.dest)
+        ]

--- a/jig/analizer/domain/__init__.py
+++ b/jig/analizer/domain/__init__.py
@@ -1,0 +1,36 @@
+import dataclasses
+from typing import List
+
+from jig.collector.domain import ModulePath, SourceCode, ModuleDependency
+
+
+@dataclasses.dataclass
+class ModuleSpace:
+    _module_path_set: List[ModulePath]
+
+    def includes(self, module_path: ModulePath) -> bool:
+        """
+        指定されたModulePathがこのModule空間に含まれるモジュールかを返す。
+        :param module_path:
+        :return:
+        """
+        return any([module_path.belongs_to(p) for p in self._module_path_set])
+
+
+@dataclasses.dataclass
+class SourceCodeList:
+    _source_codes: List[SourceCode]
+
+    def all_dependencies(self) -> List[ModuleDependency]:
+        result = []
+        for source_code in self._source_codes:
+            result += source_code.module_dependencies()
+
+        return result
+
+    def to_module_space(self) -> ModuleSpace:
+        return ModuleSpace(
+            _module_path_set=[
+                source_code.module_path for source_code in self._source_codes
+            ]
+        )

--- a/jig/cli/debug.py
+++ b/jig/cli/debug.py
@@ -14,6 +14,37 @@ from jig.visualizer.application import (
 
 
 class Main:
+    def modules(self, target_path: str, root_path: Optional[str] = None) -> None:
+        """
+        指定されたパスのモジュール名を表示します。
+        ディレクトリを指定した場合は再帰的にPythonファイルを収集し、全てのソースコード
+        のモジュール名をリストで表示します。
+        :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス
+        :return:
+        """
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
+        for source_code in source_codes:
+            print(str(source_code.module_path))
+
+    def module_imports(self, target_path: str, root_path: Optional[str] = None) -> None:
+        """
+        指定されたパスのモジュールのインポートしているモジュールリストを表示します。
+        ディレクトリを指定した場合は再帰的にPythonファイルを収集し、全てのソースコード
+        のモジュールのインポートしているモジュールをリストで表示します。
+        :param target_path: 解析対象のソースファイルまたはディレクトリへのパス
+        :param root_path: 解析対象Pythonコードのルートディレクトリパス
+        :return:
+        """
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
+        for source_code in source_codes:
+            for import_module in source_code.import_modules:
+                print(str(source_code.module_path), str(import_module.module_path))
+
     def source_codes(self, target_path: str, root_path: Optional[str] = None) -> None:
         """
         指定されたパスのPythonソースコード解析結果を表示します。

--- a/jig/cli/debug.py
+++ b/jig/cli/debug.py
@@ -4,6 +4,8 @@ from typing import Optional, List
 
 import fire
 
+from jig.analizer.application import ModuleDependencyAnalyzer
+from jig.analizer.domain import SourceCodeList
 from jig.collector.application import SourceCodeCollector
 from jig.collector.domain import SourceCode
 from jig.visualizer.application import (
@@ -44,6 +46,17 @@ class Main:
         for source_code in source_codes:
             for import_module in source_code.import_modules:
                 print(str(source_code.module_path), str(import_module.module_path))
+
+    def module_deps(self, target_path: str, root_path: Optional[str] = None) -> None:
+        source_codes = self._collect_source_codes(
+            target_path=target_path, root_path=root_path
+        )
+        analyzer = ModuleDependencyAnalyzer(
+            source_code_list=SourceCodeList(_source_codes=source_codes)
+        )
+
+        for dependency in analyzer.analyze():
+            print(str(dependency.src), str(dependency.dest))
 
     def source_codes(self, target_path: str, root_path: Optional[str] = None) -> None:
         """

--- a/jig/cli/main.py
+++ b/jig/cli/main.py
@@ -1,22 +1,23 @@
 import os
 from pathlib import Path
-from typing import List
 
 import fire
 
+from jig.analizer.application import ModuleDependencyAnalyzer
+from jig.analizer.domain import SourceCodeList
 from jig.collector.application import SourceCodeCollector
-from jig.collector.domain import SourceCode
-from jig.visualizer.application import DependencyImageVisualizer
+from jig.visualizer.application import ModuleDependencyVisualizer
 
 
-def _collect_source_codes(target_path: str) -> List[SourceCode]:
+def _collect_source_codes(target_path: str) -> SourceCodeList:
     root_path = os.getcwd()
 
-    return list(
+    source_code_list = list(
         SourceCodeCollector(root_path=Path(root_path)).collect(
             target_path=Path(target_path)
         )
     )
+    return SourceCodeList(_source_codes=source_code_list)
 
 
 def output_dependency_images(target_path, output_dir="output"):
@@ -27,11 +28,15 @@ def output_dependency_images(target_path, output_dir="output"):
     :param output_dir: 解析結果の出力ディレクトリを指定します（デフォルト: output）
     :return:
     """
+
     for depth in range(1, 6):
         source_codes = _collect_source_codes(target_path=target_path)
-        dot = DependencyImageVisualizer(source_codes=source_codes, module_names=[])
 
-        dot.visualize(depth=depth, output_dir=output_dir)
+        analyzer = ModuleDependencyAnalyzer(source_code_list=source_codes)
+        dependencies = analyzer.analyze()
+
+        visualizer = ModuleDependencyVisualizer(dependencies=dependencies)
+        visualizer.visualize(depth=depth, output_dir=output_dir)
 
 
 def main():

--- a/jig/collector/domain/__init__.py
+++ b/jig/collector/domain/__init__.py
@@ -30,6 +30,15 @@ class ModulePath:
     def depth(self):
         return len(self.names)
 
+    def path_in_depth(self, depth: int) -> "ModulePath":
+        """
+        このパスを指定されたdepthだけ辿ったパスを新たに返します
+        :param depth:
+        :return:
+        """
+        assert depth > 0
+        return ModulePath(names=self.names[:depth])
+
     def belongs_to(self, other: "ModulePath") -> bool:
         """
         パスがotherに含まれているかどうかを返します。

--- a/jig/visualizer/application/__init__.py
+++ b/jig/visualizer/application/__init__.py
@@ -3,7 +3,7 @@ import subprocess
 import textwrap
 from typing import List
 
-from jig.collector.domain import SourceCode
+from jig.collector.domain import SourceCode, ModuleDependency
 
 
 class DependencyTextVisualizer:
@@ -56,6 +56,65 @@ class DependencyImageVisualizer:
 
     def visualize(self, depth: int, output_dir: str) -> None:
         dot = self._dot_text_visualizer.visualize(depth)
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        filepath = os.path.join(output_dir, f"dependency{depth}.png")
+
+        p = subprocess.Popen(["dot", "-Tpng", f"-o{filepath}"], stdin=subprocess.PIPE)
+
+        p.communicate(dot.encode())
+
+
+class ModuleDependencyVisualizer:
+    def __init__(self, dependencies: List[ModuleDependency]):
+        self.dependencies = dependencies
+
+    def dot_text(self, depth: int) -> str:
+        result = []
+        for dep in self.dependencies:
+            path1 = str(dep.src.path_in_depth(depth))
+            path2 = str(dep.dest.path_in_depth(depth))
+
+            # 自己参照は依存関係分析的には意味ないので除く
+            if path1 == path2:
+                continue
+
+            result.append(f'"{path1}" -> "{path2}";')
+
+        # 設定テキスト
+        setting_text = """
+          graph [
+            rankdir = "LR",
+            overlap = "scale",
+            ratio = "fill",
+            fontsize = "24",
+            fontname = "Helvetica",
+            clusterrank = "local"
+            dpi = 180
+          ]
+
+          node [
+            fontsize=7
+            shape=ellipse
+          ];
+        """
+
+        # 重複削除とソート
+        edges = sorted(list(set(result)))
+        edge_text = "\n".join(edges)
+
+        graph_text = [
+            "digraph {",
+            textwrap.indent(textwrap.dedent(setting_text), "  "),
+            textwrap.indent(edge_text, "  "),
+            "}",
+        ]
+
+        return "\n".join(graph_text)
+
+    def visualize(self, depth: int, output_dir: str) -> None:
+        dot = self.dot_text(depth)
 
         os.makedirs(output_dir, exist_ok=True)
 

--- a/jig/visualizer/application/__init__.py
+++ b/jig/visualizer/application/__init__.py
@@ -16,7 +16,7 @@ class DependencyTextVisualizer:
         for source_code in self._source_codes:
             result.append(f"---- {source_code.file.module_path}")
             for dep in source_code.module_dependencies(module_names=self._module_names):
-                result.append(f"{dep[0]} -> {dep[1]}")
+                result.append(f"{dep.src} -> {dep.dest}")
 
         return "\n".join(result)
 
@@ -26,22 +26,12 @@ class DotTextVisualizer:
         self._source_codes = source_codes
         self._module_names = module_names
 
-    # SourceCodeのmodule_dependenciesで返るオブジェクトがTuple[str, str] と貧弱なので
-    # とりあえずモジュールパスを扱えるクラスを仮で実装
-    class ModuleNode:
-        def __init__(self, module_path: str):
-            self.module_path = module_path
-
-        def path(self, depth: int) -> str:
-            path_list = self.module_path.split(".")
-            return ".".join(path_list[:depth])
-
     def visualize(self, depth: int) -> str:
         result = []
         for source_code in self._source_codes:
             for dep in source_code.module_dependencies(module_names=self._module_names):
-                path1 = self.ModuleNode(module_path=dep[0]).path(depth=depth)
-                path2 = self.ModuleNode(module_path=dep[1]).path(depth=depth)
+                path1 = str(dep.src.path_in_depth(depth))
+                path2 = str(dep.dest.path_in_depth(depth))
 
                 # 自己参照は依存関係分析的には意味ないので除く
                 if path1 == path2:

--- a/tests/collector/domain/test_import_module_collection.py
+++ b/tests/collector/domain/test_import_module_collection.py
@@ -118,3 +118,12 @@ class TestImportModuleCollectionBuildByImportAST:
 
         import_modules = ImportModuleCollection.build_by_import_ast(import_ast)
         assert import_modules == mod_collections("os", "datetime.datetime")
+
+    def test_to_module_path_list(self):
+        import_ast = parse_import("import os, datetime.datetime")
+
+        import_modules = ImportModuleCollection.build_by_import_ast(import_ast)
+        assert import_modules.to_module_path_list() == [
+            ModulePath.from_str("os"),
+            ModulePath.from_str("datetime.datetime"),
+        ]

--- a/tests/collector/domain/test_module_path.py
+++ b/tests/collector/domain/test_module_path.py
@@ -32,3 +32,14 @@ class TestModulePath:
         assert m1.belongs_to(m1)
         assert not m1.belongs_to(m2)
         assert m2.belongs_to(m1)
+
+    def test_depth(self):
+        assert mod("aaa").depth == 1
+        assert mod("aaa.bbb").depth == 2
+        assert mod("aaa.bbb.ccc").depth == 3
+
+    def test_path_in_depth(self):
+        assert mod("aaa.bbb.ccc").path_in_depth(1) == mod("aaa")
+        assert mod("aaa.bbb.ccc").path_in_depth(2) == mod("aaa.bbb")
+        assert mod("aaa.bbb.ccc").path_in_depth(3) == mod("aaa.bbb.ccc")
+        assert mod("aaa.bbb.ccc").path_in_depth(4) == mod("aaa.bbb.ccc")

--- a/tests/collector/domain/test_module_path.py
+++ b/tests/collector/domain/test_module_path.py
@@ -24,3 +24,11 @@ class TestModulePath:
 
         assert m1 + m2 == mod("aaa.bbb.xxx.yyy")
         assert m2 + m1 == mod("xxx.yyy.aaa.bbb")
+
+    def test_belongs_to(self):
+        m1 = mod("aaa.bbb")
+        m2 = mod("aaa.bbb.ccc")
+
+        assert m1.belongs_to(m1)
+        assert not m1.belongs_to(m2)
+        assert m2.belongs_to(m1)

--- a/tests/collector/domain/test_source_code.py
+++ b/tests/collector/domain/test_source_code.py
@@ -5,6 +5,8 @@ from jig.collector.domain import (
     SourceFile,
     SourceCodeCollection,
     SourceFilePath,
+    ModuleDependency,
+    ModulePath,
 )
 
 
@@ -51,5 +53,9 @@ class TestSourceCode:
             )
         )
 
-        assert code.module_dependencies(module_names=[]) == [("main", "os.path")]
+        assert code.module_dependencies() == [
+            ModuleDependency(
+                src=ModulePath.from_str("main"), dest=ModulePath.from_str("os.path")
+            )
+        ]
         assert code.module_dependencies(module_names=["jig"]) == []


### PR DESCRIPTION
標準モジュールを除外することも考えたんですが、逆に解析対象のファイルに着目してその依存関係だけ出力してみるようにしました。

これまでいったんVisualizer内で依存関係の抽出も行なっていましたが、解析する層を間に追加した方が良さそうだったのでここでanalyzerの層を追加しています。