### PR TITLE
Jig.analyze_module_dependency() には root ディレクトリを指定する

### DIFF
--- a/jig/cli/interaction.py
+++ b/jig/cli/interaction.py
@@ -14,8 +14,8 @@ from jig.visualizer.module_dependency.presentation.controller.graph_controller i
 @dataclasses.dataclass
 class Jig:
     @classmethod
-    def analyze_module_dependency(cls, target_path: str) -> GraphController:
-        source_codes = _collect_source_codes(target_path=target_path)
+    def analyze_module_dependency(cls, project_root_path: str) -> GraphController:
+        source_codes = _collect_source_codes(project_root_path=project_root_path)
 
         collection = ImportDependencyCollection.build_from_source_code_collection(
             source_codes

--- a/jig/cli/main.py
+++ b/jig/cli/main.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import fire
@@ -9,25 +8,22 @@ from jig.collector.domain.source_code.source_code_collection import SourceCodeCo
 from jig.visualizer.application import ModuleDependencyVisualizer
 
 
-def _collect_source_codes(target_path: str) -> SourceCodeCollection:
-    root_path = os.getcwd()
-
-    return SourceCodeCollector(root_path=Path(root_path)).collect(
-        target_path=Path(target_path)
+def _collect_source_codes(project_root_path: str) -> SourceCodeCollection:
+    return SourceCodeCollector(root_path=Path(project_root_path)).collect(
+        target_path=Path(project_root_path)
     )
 
 
-def output_dependency_images(target_path, output_dir="output"):
+def output_dependency_images(project_root_path, output_dir="output"):
     """
     指定されたディレクトリ以下を解析し、その結果を出力ディレクトリに出力します。
-    各Pythonファイルのモジュール名は、実行時のカレントディレクトリをPYTHONPATHとして解釈されます。
-    :param target_path: 解析対象のパスを指定します。
+    :param project_root_path: 解析対象プロジェクトのプロジェクトルートパスを指定します。
     :param output_dir: 解析結果の出力ディレクトリを指定します（デフォルト: output）
     :return:
     """
 
     for depth in range(1, 8):
-        source_codes = _collect_source_codes(target_path=target_path)
+        source_codes = _collect_source_codes(project_root_path=project_root_path)
 
         collection = ImportDependencyCollection.build_from_source_code_collection(
             source_codes

--- a/jig/collector/domain/source_file/source_file_path.py
+++ b/jig/collector/domain/source_file/source_file_path.py
@@ -82,3 +82,18 @@ class SourceFilePath:
     @property
     def is_package(self):
         return self.file_path.stem == "__init__"
+
+    @property
+    def can_convert_to_module_path(self) -> bool:
+        """
+        パスがモジュールパスとして扱えるかどうかを返す。
+        :return:
+        """
+        # ディレクトリパスをチェック
+        dir_path = str(self.relative_path_from_root.parent)
+        if dir_path != "." and dir_path.find(".") >= 0:
+            return False
+
+        # ファイル名の拡張子を外してチェック
+        name = self.relative_path_from_root.stem
+        return name.find(".") < 0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 
 name = "jig-py"
-version = "0.0.8"
+version = "0.0.9"
 description = "Jig for Python"
 dependencies = [
     "fire",

--- a/tests/collector/domain/test_source_file_path.py
+++ b/tests/collector/domain/test_source_file_path.py
@@ -41,6 +41,27 @@ class TestSourceFilePath:
         assert path.is_package
         assert path.module_path == ModulePath.from_str("path.to")
 
+    def test_can_convert_to_module_path__package(self):
+        path = SourceFilePath(
+            root_path=Path("root"), file_path=Path("root/path/to/__init__.py")
+        )
+
+        assert path.can_convert_to_module_path is True
+
+    def test_can_convert_to_module_path__file(self):
+        path = SourceFilePath(root_path=Path("root"), file_path=Path("root/main.py"))
+        assert path.can_convert_to_module_path is True
+
+    def test_can_convert_to_module_path__invalid_file(self):
+        path = SourceFilePath(root_path=Path("root"), file_path=Path("root/.main.py"))
+        assert path.can_convert_to_module_path is False
+
+    def test_can_convert_to_module_path__invalid_path(self):
+        path = SourceFilePath(
+            root_path=Path("root"), file_path=Path("root/.hidden/main.py")
+        )
+        assert path.can_convert_to_module_path is False
+
 
 class TestSourceFilePathResolveImportFrom:
     ROOT_PATH = Path("/jig-py")


### PR DESCRIPTION
jig-py 自身を指定すると venv/ の中身が解析対象に含まれてエラーになってしまうので、
モジュールパスとして解決できないファイルは解析対象から除外する処理も追加。