### PR TITLE
GraphController の使い勝手向上

### DIFF
--- a/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
+++ b/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import Union, List
 
 from graphviz import Digraph
 
@@ -34,42 +33,41 @@ class GraphController:
 
         return cls(g)
 
-    def remove(self, node_name: str) -> "GraphController":
-        node = ModuleNode.from_str(node_name)
-        self.graph.remove_node(node)
+    def remove(self, *node_names: str) -> "GraphController":
+        for node_name in node_names:
+            node = ModuleNode.from_str(node_name)
+            self.graph.remove_node(node)
         return self
 
-    def dig(self, node_name: str) -> "GraphController":
-        node = ModuleNode.from_str(node_name)
-        self.graph.dig(node)
+    def dig(self, *node_names: str) -> "GraphController":
+        for node_name in node_names:
+            node = ModuleNode.from_str(node_name)
+            self.graph.dig(node)
         return self
 
     def render(self) -> Digraph:
         renderer = GraphRenderer(self.graph)
         return renderer.render()
 
-    def hide(self, node_name: str) -> "GraphController":
-        node = ModuleNode.from_str(node_name)
-        self.graph.hide_node(node)
+    def hide(self, *node_names: str) -> "GraphController":
+        for node_name in node_names:
+            node = ModuleNode.from_str(node_name)
+            self.graph.hide_node(node)
         return self
 
     def style(
         self,
-        node_names: Union[str, List[str]],
+        *node_names: str,
         color: str = "black",
         fontcolor: str = "black",
         penwidth: str = "normal",
     ) -> "GraphController":
-        if isinstance(node_names, str):
-            nodes = [ModuleNode.from_str(node_names)]
-        else:
-            nodes = [ModuleNode.from_str(n) for n in node_names]
-
         color_ = Color(color)
         fontcolor_ = Color(fontcolor)
         penwidth_ = PenWidth(penwidth)
 
-        for node in nodes:
+        for node_name in node_names:
+            node = ModuleNode.from_str(node_name)
             self.graph.style(
                 node=node, color=color_, fontcolor=fontcolor_, penwidth=penwidth_
             )

--- a/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
+++ b/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
@@ -73,3 +73,15 @@ class GraphController:
 
     def auto_highlight(self):
         self.graph.auto_highlight()
+
+    def _repr_svg_(self):
+        """
+        Jupyter 上でオブジェクト自身を評価したときグラフ描画されるようにする。
+
+        https://ipython.readthedocs.io/en/stable/config/integrating.html#rich-display
+        :return:
+        """
+        g = self.render()
+
+        # graphvizの実装に移譲する
+        return g._repr_svg_()

--- a/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
+++ b/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
@@ -34,21 +34,24 @@ class GraphController:
 
         return cls(g)
 
-    def remove(self, node_name: str):
+    def remove(self, node_name: str) -> "GraphController":
         node = ModuleNode.from_str(node_name)
         self.graph.remove_node(node)
+        return self
 
-    def dig(self, node_name: str):
+    def dig(self, node_name: str) -> "GraphController":
         node = ModuleNode.from_str(node_name)
         self.graph.dig(node)
+        return self
 
     def render(self) -> Digraph:
         renderer = GraphRenderer(self.graph)
         return renderer.render()
 
-    def hide(self, node_name: str):
+    def hide(self, node_name: str) -> "GraphController":
         node = ModuleNode.from_str(node_name)
         self.graph.hide_node(node)
+        return self
 
     def style(
         self,
@@ -56,7 +59,7 @@ class GraphController:
         color: str = "black",
         fontcolor: str = "black",
         penwidth: str = "normal",
-    ):
+    ) -> "GraphController":
         if isinstance(node_names, str):
             nodes = [ModuleNode.from_str(node_names)]
         else:
@@ -70,9 +73,11 @@ class GraphController:
             self.graph.style(
                 node=node, color=color_, fontcolor=fontcolor_, penwidth=penwidth_
             )
+        return self
 
-    def auto_highlight(self):
+    def auto_highlight(self) -> "GraphController":
         self.graph.auto_highlight()
+        return self
 
     def _repr_svg_(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 
 name = "jig-py"
-version = "0.0.9"
+version = "0.0.10"
 description = "Jig for Python"
 dependencies = [
     "fire",


### PR DESCRIPTION
* render() を呼ばなくてもグラフ描画されるように修正
  * GraphControllerをJupyter上で評価したときグラフ描画されるようにする
  * GraphControllerの各操作メソッドが自分自身を返すようにし、即座にレンダリングされるようにする
* 複数のノードを引数として受け取れるように修正
  * style() メソッドは他と合わせて複数ノード指定時に `[]` を書かなくて済むように可変長引数を受け取るように変更

![image](https://user-images.githubusercontent.com/1888342/91116143-ad157880-e6c6-11ea-9ac9-cdda4b63be11.png)
![image](https://user-images.githubusercontent.com/1888342/91116212-d8986300-e6c6-11ea-9054-478001c8e64a.png)
