### PR TITLE
digしたときにクラスタ内にエッジなしのノードがあるとエラーになる問題を修正

### DIFF
--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -310,7 +310,9 @@ class Graph:
     ):
         cluster = Cluster(node=node)
         for n in self.master_graph.find_nodes(node):
-            cluster.add(n.limit_path_level(next_path_level))
+            new_node = n.limit_path_level(next_path_level)
+            cluster.add(new_node)
+            self.add_node(new_node)
 
         node_owner.add_cluster(cluster)
 

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -88,8 +88,11 @@ class Graph:
 
     def add_cluster(self, cluster: Cluster):
         not_included = cluster.children - self.nodes
-        if not_included:
-            raise ValueError(f"Graphのnodesに含まれないchildrenがあります: {not_included}")
+
+        # 親グラフが全てのノード情報を持つ前提条件を守るため、
+        # 親グラフに含まれないノードを親グラフのノード管理に含める
+        for node in not_included:
+            self.add_node(node)
 
         self.clusters[cluster.node] = cluster
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 
 name = "jig-py"
-version = "0.0.14"
+version = "0.0.15"
 description = "Jig for Python"
 dependencies = [
     "fire",

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -597,7 +597,16 @@ class TestGraph:
         with pytest.raises(ValueError):
             g.dig(node("foo"))
 
+
+class TestGraphScenario:
+    """
+    複数の操作を行うシナリオテスト
+    """
+
     def test_remove_and_dig(self):
+        """
+        エッジの生えていないクラスタ内ノードが発生したとき、エラーにならずそのノードがGraphのnodesに追加されること
+        """
         master_graph = MasterGraph.from_tuple_list(
             [
                 ("tests.fixtures", "jig.visualizer"),
@@ -627,6 +636,52 @@ class TestGraph:
                 "tests": {
                     "nodes": ["tests.fixtures", "tests.visualizer"],
                     "clusters": {},
+                }
+            },
+        }
+
+    def test_remove_and_dig_inside_cluster(self):
+        """
+        エッジの生えていないノードがネストされたクラスタ内で発生したとき、そのノードがGraphのnodesに追加されること
+        """
+        master_graph = MasterGraph.from_tuple_list(
+            [("tests.fixtures.download", "jig.visualizer")]
+        )
+
+        g = Graph(master_graph=master_graph)
+        assert g.to_dict() == {
+            "nodes": ["jig", "tests"],
+            "edges": [("tests", "jig")],
+            "clusters": {},
+        }
+
+        g.dig(node("tests"))
+        assert g.to_dict() == {
+            "nodes": ["jig", "tests.fixtures"],
+            "edges": [("tests.fixtures", "jig")],
+            "clusters": {"tests": {"nodes": ["tests.fixtures"], "clusters": {}}},
+        }
+
+        g.remove_node(node("jig"))
+        assert g.to_dict() == {
+            "nodes": ["tests.fixtures"],
+            "edges": [],
+            "clusters": {"tests": {"nodes": ["tests.fixtures"], "clusters": {}}},
+        }
+
+        g.dig(node("tests.fixtures"))
+        assert g.to_dict() == {
+            "nodes": ["tests.fixtures.download"],
+            "edges": [],
+            "clusters": {
+                "tests": {
+                    "nodes": [],
+                    "clusters": {
+                        "tests.fixtures": {
+                            "nodes": ["tests.fixtures.download"],
+                            "clusters": {},
+                        }
+                    },
                 }
             },
         }


### PR DESCRIPTION
`add_cluster()` と `dig()` のそれぞれで対応していてちょっと無駄がある（ノード追加処理が重複する場合がある）んですが、ひとまず対応。