### PR TITLE
remove() したものを復元する restore() を追加

### DIFF
--- a/jig/collector/domain/ast/__init__.py
+++ b/jig/collector/domain/ast/__init__.py
@@ -109,7 +109,12 @@ class ClassDefVisitor(ast.NodeVisitor):
     class_defs: List[ClassDef] = dataclasses.field(default_factory=list)
 
     def visit_ClassDef(self, node):
-        self.class_defs.append(ClassDef(name=node.name, _ast=node,))
+        self.class_defs.append(
+            ClassDef(
+                name=node.name,
+                _ast=node,
+            )
+        )
 
 
 @dataclasses.dataclass

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -61,6 +61,14 @@ class Graph:
 
         return sorted(modules)
 
+    def list_all_nodes(self) -> List[ModuleNode]:
+        """Graphに含まれる全てのノードを返す（クラスタ自身はノードではないがクラスタ内のノードは含まれる）"""
+        nodes = set(self.nodes)
+        for cluster in self.clusters.values():
+            nodes.update(cluster.descendant_nodes())
+
+        return sorted(nodes)
+
     def find_cluster(self, path: ModulePath) -> Optional[Cluster]:
         for cluster in self.clusters.values():
             if cluster.module_path == path:

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -142,6 +142,32 @@ class Graph:
 
         return True
 
+    def _find_or_create_clusters(self, path: ModulePath) -> Cluster:
+        assert self.master_graph.has_module(path)
+
+        holder: Union[Graph, Cluster] = self
+        cluster = None
+        for i in range(1, path.path_level + 1):
+            cluster_path = path.path_in_depth(i)
+            cluster = next(
+                (
+                    cluster
+                    for cluster in holder.clusters.values()
+                    if cluster.module_path == cluster_path
+                ),
+                None,
+            )
+
+            if not cluster:
+                cluster = Cluster(module_path=cluster_path)
+                holder.add_cluster(cluster)
+
+            holder = cluster
+
+        assert cluster is not None
+
+        return cluster
+
     def _remove_node_from_cluster(self, node: ModuleNode):
         # Dict#values() で for を回しているときには、要素削除できないので、 List にキャストする
         for cluster in list(self.clusters.values()):

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -124,6 +124,15 @@ class Graph:
 
         self._remove_node_from_cluster(node)
 
+    def is_removed_node(self, node: ModuleNode) -> bool:
+        if node in self.list_all_nodes():
+            return False
+
+        if not self.master_graph.has_module(node.path):
+            return False
+
+        return True
+
     def _remove_node_from_cluster(self, node: ModuleNode):
         # Dict#values() で for を回しているときには、要素削除できないので、 List にキャストする
         for cluster in list(self.clusters.values()):

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -52,6 +52,14 @@ class Graph:
 
         return {"nodes": nodes, "edges": edges, "clusters": clusters}
 
+    def list_all_nodes(self) -> List[ModuleNode]:
+        """クラスタも含めた全てのノードを返す"""
+        nodes = set(self.nodes)
+        for cluster in self.clusters.values():
+            nodes.update(cluster.list_all_nodes())
+
+        return sorted(nodes)
+
     def find_cluster(self, node: ModuleNode) -> Optional[Cluster]:
         for cluster in self.clusters.values():
             if cluster.node == node:

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -61,12 +61,12 @@ class Graph:
 
         return sorted(modules)
 
-    def find_cluster(self, node: ModuleNode) -> Optional[Cluster]:
+    def find_cluster(self, path: ModulePath) -> Optional[Cluster]:
         for cluster in self.clusters.values():
-            if cluster.module_path == node.path:
+            if cluster.module_path == path:
                 return cluster
 
-            sub_cluster = cluster.find_cluster(node)
+            sub_cluster = cluster.find_cluster(path)
             if sub_cluster:
                 return sub_cluster
 
@@ -142,8 +142,8 @@ class Graph:
             if cluster.is_empty:
                 del self.clusters[cluster.module_path]
 
-    def remove_cluster(self, node: ModuleNode):
-        cluster = self.find_cluster(node)
+    def remove_cluster(self, path: ModulePath):
+        cluster = self.find_cluster(path)
         if not cluster:
             return
 
@@ -178,7 +178,7 @@ class Graph:
         focus_nodes = set()
 
         for node in input_nodes:
-            cluster = self.find_cluster(node)
+            cluster = self.find_cluster(node.path)
             if cluster:
                 focus_nodes |= set(cluster.descendant_nodes())
                 continue

--- a/jig/visualizer/module_dependency/domain/model/graph.py
+++ b/jig/visualizer/module_dependency/domain/model/graph.py
@@ -12,6 +12,7 @@ from jig.visualizer.module_dependency.domain.value.module_node import (
     ModuleNode,
     ModuleNodeStyle,
 )
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 from jig.visualizer.module_dependency.domain.value.penwidth import Color, PenWidth
 
 
@@ -52,13 +53,13 @@ class Graph:
 
         return {"nodes": nodes, "edges": edges, "clusters": clusters}
 
-    def list_all_nodes(self) -> List[ModuleNode]:
-        """クラスタも含めた全てのノードを返す"""
-        nodes = set(self.nodes)
+    def list_all_modules(self) -> List[ModulePath]:
+        """クラスタも含めたGraphに含まれる全てのモジュールパスを返す"""
+        modules = set([node.path for node in self.nodes])
         for cluster in self.clusters.values():
-            nodes.update(cluster.list_all_nodes())
+            modules.update(cluster.list_all_modules())
 
-        return sorted(nodes)
+        return sorted(modules)
 
     def find_cluster(self, node: ModuleNode) -> Optional[Cluster]:
         for cluster in self.clusters.values():
@@ -125,7 +126,7 @@ class Graph:
         self._remove_node_from_cluster(node)
 
     def is_removed_node(self, node: ModuleNode) -> bool:
-        if node in self.list_all_nodes():
+        if node.path in self.list_all_modules():
             return False
 
         if not self.master_graph.has_module(node.path):

--- a/jig/visualizer/module_dependency/domain/model/master_graph.py
+++ b/jig/visualizer/module_dependency/domain/model/master_graph.py
@@ -6,6 +6,7 @@ from jig.visualizer.module_dependency.domain.value.module_edge import (
     ModuleEdgeCollection,
 )
 from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 
 
 @dataclasses.dataclass
@@ -17,6 +18,13 @@ class MasterGraph:
     @classmethod
     def from_tuple_list(cls, edges: List[Tuple[str, str]]) -> "MasterGraph":
         return cls(ModuleEdgeCollection.from_tuple_list(edges))
+
+    def has_module(self, path: ModulePath) -> bool:
+        for edge in self.edges:
+            if any([node.path.belongs_to(path) for node in [edge.tail, edge.head]]):
+                return True
+
+        return False
 
     def find_parent_edge(self, edge: ModuleEdge) -> Optional[ModuleEdge]:
         return self.edges.find_parent_edge(edge=edge)

--- a/jig/visualizer/module_dependency/domain/model/master_graph.py
+++ b/jig/visualizer/module_dependency/domain/model/master_graph.py
@@ -6,6 +6,9 @@ from jig.visualizer.module_dependency.domain.value.module_edge import (
     ModuleEdgeCollection,
 )
 from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_node_adjacent import (
+    ModuleNodeAdjacentGraph,
+)
 from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 
 
@@ -25,6 +28,32 @@ class MasterGraph:
                 return True
 
         return False
+
+    def find_adjacent_graph(
+        self, node: ModuleNode
+    ) -> Optional[ModuleNodeAdjacentGraph]:
+        """指定されたノードに隣接するノードを持ったModuleNodeAdjacentを探して返す"""
+        if not self.has_module(node.path):
+            return None
+
+        outgoing_nodes = set()
+        incoming_nodes = set()
+        for edge in self.edges:
+            if edge.tail.belongs_to(node):
+                # ignore self inner edges
+                if not edge.head.belongs_to(node):
+                    outgoing_nodes.add(edge.head)
+
+            if edge.head.belongs_to(node):
+                # ignore self inner edges
+                if not edge.tail.belongs_to(node):
+                    incoming_nodes.add(edge.tail)
+
+        return ModuleNodeAdjacentGraph(
+            node=node,
+            incoming_nodes=sorted(incoming_nodes),
+            outgoing_nodes=sorted(outgoing_nodes),
+        )
 
     def find_parent_edge(self, edge: ModuleEdge) -> Optional[ModuleEdge]:
         return self.edges.find_parent_edge(edge=edge)

--- a/jig/visualizer/module_dependency/domain/value/cluster.py
+++ b/jig/visualizer/module_dependency/domain/value/cluster.py
@@ -7,9 +7,9 @@ from .module_node import ModuleNode
 
 @dataclasses.dataclass
 class Cluster:
-    node: ModuleNode
+    module_path: ModulePath
     children: Set[ModuleNode] = dataclasses.field(default_factory=set)
-    clusters: Dict[ModuleNode, "Cluster"] = dataclasses.field(default_factory=dict)
+    clusters: Dict[ModulePath, "Cluster"] = dataclasses.field(default_factory=dict)
 
     def to_dict(self) -> dict:
         nodes = sorted([n.name for n in self.children])
@@ -27,7 +27,7 @@ class Cluster:
         return all([cluster.is_empty for cluster in self.clusters.values()])
 
     def list_all_modules(self) -> List[ModulePath]:
-        modules = {self.node.path}
+        modules = {self.module_path}
         modules.update([node.path for node in self.children])
 
         for cluster in self.clusters.values():
@@ -51,7 +51,7 @@ class Cluster:
 
     def find_cluster(self, node: ModuleNode) -> Optional["Cluster"]:
         for cluster in self.clusters.values():
-            if cluster.node == node:
+            if cluster.module_path == node.path:
                 return cluster
 
             sub_cluster = cluster.find_cluster(node)
@@ -75,7 +75,7 @@ class Cluster:
         self.children.add(node)
 
     def add_cluster(self, cluster: "Cluster"):
-        self.clusters[cluster.node] = cluster
+        self.clusters[cluster.module_path] = cluster
 
     def remove(self, node: ModuleNode):
         if node in self.children:
@@ -84,7 +84,7 @@ class Cluster:
         for cluster in list(self.clusters.values()):
             cluster.remove(node)
             if cluster.is_empty:
-                del self.clusters[cluster.node]
+                del self.clusters[cluster.module_path]
 
     def hide_node(self, node: ModuleNode):
         if node in self.children:

--- a/jig/visualizer/module_dependency/domain/value/cluster.py
+++ b/jig/visualizer/module_dependency/domain/value/cluster.py
@@ -1,6 +1,7 @@
 import dataclasses
 from typing import Set, Dict, Optional, List
 
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 from .module_node import ModuleNode
 
 
@@ -25,14 +26,14 @@ class Cluster:
 
         return all([cluster.is_empty for cluster in self.clusters.values()])
 
-    def list_all_nodes(self) -> List[ModuleNode]:
-        nodes = {self.node}
-        nodes.update(self.children)
+    def list_all_modules(self) -> List[ModulePath]:
+        modules = {self.node.path}
+        modules.update([node.path for node in self.children])
 
         for cluster in self.clusters.values():
-            nodes.update(cluster.list_all_nodes())
+            modules.update(cluster.list_all_modules())
 
-        return sorted(nodes)
+        return sorted(modules)
 
     def descendant_nodes(self) -> List[ModuleNode]:
         """

--- a/jig/visualizer/module_dependency/domain/value/cluster.py
+++ b/jig/visualizer/module_dependency/domain/value/cluster.py
@@ -25,6 +25,15 @@ class Cluster:
 
         return all([cluster.is_empty for cluster in self.clusters.values()])
 
+    def list_all_nodes(self) -> List[ModuleNode]:
+        nodes = {self.node}
+        nodes.update(self.children)
+
+        for cluster in self.clusters.values():
+            nodes.update(cluster.list_all_nodes())
+
+        return sorted(nodes)
+
     def descendant_nodes(self) -> List[ModuleNode]:
         """
         クラスタに含まれる子孫ノード（子クラスタのノードを含む）を返す。

--- a/jig/visualizer/module_dependency/domain/value/cluster.py
+++ b/jig/visualizer/module_dependency/domain/value/cluster.py
@@ -49,12 +49,12 @@ class Cluster:
 
         return nodes
 
-    def find_cluster(self, node: ModuleNode) -> Optional["Cluster"]:
+    def find_cluster(self, path: ModulePath) -> Optional["Cluster"]:
         for cluster in self.clusters.values():
-            if cluster.module_path == node.path:
+            if cluster.module_path == path:
                 return cluster
 
-            sub_cluster = cluster.find_cluster(node)
+            sub_cluster = cluster.find_cluster(path)
             if sub_cluster:
                 return sub_cluster
 

--- a/jig/visualizer/module_dependency/domain/value/module_node_adjacent.py
+++ b/jig/visualizer/module_dependency/domain/value/module_node_adjacent.py
@@ -1,0 +1,11 @@
+import dataclasses
+from typing import List
+
+from .module_node import ModuleNode
+
+
+@dataclasses.dataclass()
+class ModuleNodeAdjacentGraph:
+    node: ModuleNode
+    incoming_nodes: List[ModuleNode]
+    outgoing_nodes: List[ModuleNode]

--- a/jig/visualizer/module_dependency/domain/value/module_path.py
+++ b/jig/visualizer/module_dependency/domain/value/module_path.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List
+from typing import List, Optional
 
 
 @dataclasses.dataclass(frozen=True)
@@ -20,6 +20,11 @@ class ModulePath:
 
     def __lt__(self, other: "ModulePath"):
         return self.name < other.name
+
+    def parent(self) -> Optional["ModulePath"]:
+        if self.path_level == 1:
+            return None
+        return self.path_in_depth(self.path_level - 1)
 
     def belongs_to(self, other: "ModulePath") -> bool:
         if self.path_level < other.path_level:

--- a/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
+++ b/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
@@ -2,7 +2,10 @@ import dataclasses
 
 from graphviz import Digraph
 
-from jig.visualizer.module_dependency.domain.model.graph import Graph
+from jig.visualizer.module_dependency.domain.model.graph import (
+    Graph,
+    InvalidRestoreTargetError,
+)
 from jig.visualizer.module_dependency.domain.model.master_graph import MasterGraph
 from jig.visualizer.module_dependency.domain.value.module_edge import (
     ModuleEdge,
@@ -38,6 +41,17 @@ class GraphController:
             node = ModuleNode.from_str(node_name)
             self.graph.remove_node(node)
             self.graph.remove_cluster(node.path)
+        return self
+
+    def restore(self, *node_names: str) -> "GraphController":
+        for node_name in node_names:
+            node = ModuleNode.from_str(node_name)
+
+            try:
+                self.graph.restore_node(node)
+            except InvalidRestoreTargetError:
+                pass
+
         return self
 
     def focus(self, node_name: str, *extra_node_names: str) -> "GraphController":

--- a/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
+++ b/jig/visualizer/module_dependency/presentation/controller/graph_controller.py
@@ -37,7 +37,7 @@ class GraphController:
         for node_name in node_names:
             node = ModuleNode.from_str(node_name)
             self.graph.remove_node(node)
-            self.graph.remove_cluster(node)
+            self.graph.remove_cluster(node.path)
         return self
 
     def focus(self, node_name: str, *extra_node_names: str) -> "GraphController":

--- a/jig/visualizer/module_dependency/presentation/renderer/cluster_renderer.py
+++ b/jig/visualizer/module_dependency/presentation/renderer/cluster_renderer.py
@@ -14,8 +14,8 @@ class ClusterRenderer:
         return cls(cluster=cluster)
 
     def render(self) -> Digraph:
-        g = Digraph(name=f"cluster_{self.cluster.node.name}")
-        g.attr(label=self.cluster.node.name)
+        g = Digraph(name=f"cluster_{self.cluster.module_path.name}")
+        g.attr(label=self.cluster.module_path.name)
 
         for node in sorted(self.cluster.children):
             g.node(node.name)

--- a/tests/collector/domain/test_source_code_ast.py
+++ b/tests/collector/domain/test_source_code_ast.py
@@ -26,7 +26,9 @@ import os, datetime
         """
 
         file = SourceFile(
-            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+            source_file_path=self.SOURCE_FILE_PATH,
+            content=content,
+            size=len(content),
         )
         ast = SourceCode.build(file)
 
@@ -39,7 +41,9 @@ import datetime as dt
         """
 
         file = SourceFile(
-            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+            source_file_path=self.SOURCE_FILE_PATH,
+            content=content,
+            size=len(content),
         )
         ast = SourceCode.build(file)
 
@@ -51,7 +55,9 @@ from os import path
         """
 
         file = SourceFile(
-            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+            source_file_path=self.SOURCE_FILE_PATH,
+            content=content,
+            size=len(content),
         )
         ast = SourceCode.build(file)
 
@@ -67,7 +73,9 @@ from .. import jig_ast
         """
 
         file = SourceFile(
-            source_file_path=self.SOURCE_FILE_PATH, content=content, size=len(content),
+            source_file_path=self.SOURCE_FILE_PATH,
+            content=content,
+            size=len(content),
         )
         ast = SourceCode.build(file)
 

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -260,6 +260,23 @@ class TestGraph:
             "clusters": {"jig": {"clusters": {}, "nodes": ["jig.cli"]}},
         }
 
+    def test_list_all_nodes(self):
+        g = Graph()
+        g.add_edge(edge("A", "B"))
+
+        cluster_a = cluster("pkg", {"A"})
+        cluster_b = cluster("pkg.xxx", {"B"})
+
+        cluster_a.add_cluster(cluster_b)
+        g.add_cluster(cluster_a)
+
+        assert g.list_all_nodes() == [
+            node("A"),
+            node("B"),
+            node("pkg"),
+            node("pkg.xxx"),
+        ]
+
     def test_focus(self):
         g = Graph()
         g.add_edge(edge("A", "B"))

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -40,9 +40,9 @@ class TestGraph:
         cluster_a.add_cluster(cluster_b)
         g.add_cluster(cluster_a)
 
-        assert g.find_cluster(node("x")) is None
-        assert g.find_cluster(node("pkg_A")) is cluster_a
-        assert g.find_cluster(node("pkg_B")) is cluster_b
+        assert g.find_cluster(path("x")) is None
+        assert g.find_cluster(path("pkg_A")) is cluster_a
+        assert g.find_cluster(path("pkg_B")) is cluster_b
 
     def test_find_node_owner(self):
         g = Graph()
@@ -164,7 +164,7 @@ class TestGraph:
             "clusters": {"pkg": {"nodes": ["A"], "clusters": {}}},
         }
 
-        g.remove_cluster(node("pkg"))
+        g.remove_cluster(path("pkg"))
 
         assert g.to_dict() == {
             "nodes": ["B"],
@@ -173,7 +173,7 @@ class TestGraph:
         }
 
         # 冪等なこと
-        g.remove_cluster(node("pkg"))
+        g.remove_cluster(path("pkg"))
 
         assert g.to_dict() == {
             "nodes": ["B"],
@@ -219,7 +219,7 @@ class TestGraph:
             },
         }
 
-        g.remove_cluster(node("jig"))
+        g.remove_cluster(path("jig"))
         assert g.to_dict() == {"nodes": [], "edges": [], "clusters": {}}
 
     def test_remove_cluster__child_cluster(self):
@@ -260,7 +260,7 @@ class TestGraph:
             },
         }
 
-        g.remove_cluster(node("jig.collector"))
+        g.remove_cluster(path("jig.collector"))
         assert g.to_dict() == {
             "nodes": ["jig.cli"],
             "edges": [],

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -23,7 +23,9 @@ def edge(tail: str, head: str) -> ModuleEdge:
 
 
 def cluster(name: str, children: Set[str]) -> Cluster:
-    return Cluster(node=node(name), children=set([node(name) for name in children]))
+    return Cluster(
+        module_path=path(name), children=set([node(name) for name in children])
+    )
 
 
 class TestGraph:
@@ -90,7 +92,7 @@ class TestGraph:
             "clusters": {"pkg": {"nodes": ["A", "B"], "clusters": {}}},
         }
 
-        g.clusters[node("pkg")].add_cluster(cluster("pkg.child", {"C"}))
+        g.clusters[path("pkg")].add_cluster(cluster("pkg.child", {"C"}))
         assert g.to_dict() == {
             "nodes": ["A", "B"],
             "edges": [("A", "B")],

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -284,6 +284,23 @@ class TestGraph:
             path("pkg.xxx"),
         ]
 
+    def test_list_all_nodes(self):
+        g = Graph()
+        g.add_edge(edge("A", "B"))
+        g.add_edge(edge("A", "C"))
+
+        cluster_a = cluster("pkg", {"A"})
+        cluster_b = cluster("pkg.xxx", {"B"})
+
+        cluster_a.add_cluster(cluster_b)
+        g.add_cluster(cluster_a)
+
+        assert g.list_all_nodes() == [
+            node("A"),
+            node("B"),
+            node("C"),
+        ]
+
     def test_is_removed_node(self):
         # クラスタ内クラスタの削除
         master_graph = MasterGraph.from_tuple_list(

--- a/tests/visualizer/module_dependency/domain/model/test_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_graph.py
@@ -7,6 +7,11 @@ from jig.visualizer.module_dependency.domain.model.master_graph import MasterGra
 from jig.visualizer.module_dependency.domain.value.cluster import Cluster
 from jig.visualizer.module_dependency.domain.value.module_edge import ModuleEdge
 from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
+
+
+def path(name: str) -> ModulePath:
+    return ModulePath(name)
 
 
 def node(name: str) -> ModuleNode:
@@ -260,7 +265,7 @@ class TestGraph:
             "clusters": {"jig": {"clusters": {}, "nodes": ["jig.cli"]}},
         }
 
-    def test_list_all_nodes(self):
+    def test_list_all_modules(self):
         g = Graph()
         g.add_edge(edge("A", "B"))
 
@@ -270,11 +275,11 @@ class TestGraph:
         cluster_a.add_cluster(cluster_b)
         g.add_cluster(cluster_a)
 
-        assert g.list_all_nodes() == [
-            node("A"),
-            node("B"),
-            node("pkg"),
-            node("pkg.xxx"),
+        assert g.list_all_modules() == [
+            path("A"),
+            path("B"),
+            path("pkg"),
+            path("pkg.xxx"),
         ]
 
     def test_is_removed_node(self):

--- a/tests/visualizer/module_dependency/domain/model/test_master_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_master_graph.py
@@ -1,0 +1,27 @@
+from jig.visualizer.module_dependency.domain.model.master_graph import MasterGraph
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
+
+
+def path(name: str) -> ModulePath:
+    return ModulePath(name)
+
+
+class TestMasterGraph:
+    def test_has_module(self):
+        master_graph = MasterGraph.from_tuple_list(
+            [
+                ("jig.collector.application", "jig.collector.domain.source_code"),
+                ("jig.collector.application", "jig.collector.domain.source_file"),
+                (
+                    "jig.collector.domain.source_code",
+                    "jig.collector.domain.source_file",
+                ),
+                ("jig.cli.main", "jig.collector.application"),
+            ]
+        )
+
+        assert master_graph.has_module(path("jig")) is True
+        assert master_graph.has_module(path("jig.cli")) is True
+        assert master_graph.has_module(path("jig.cli.main")) is True
+        assert master_graph.has_module(path("jig.collector.domain.source_file")) is True
+        assert master_graph.has_module(path("jig.no_module")) is False

--- a/tests/visualizer/module_dependency/domain/model/test_master_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_master_graph.py
@@ -50,7 +50,9 @@ class TestMasterGraph:
         assert m.find_adjacent_graph(node("none")) is None
 
         assert m.find_adjacent_graph(node("jig")) == ModuleNodeAdjacentGraph(
-            node=node("jig"), incoming_nodes=[], outgoing_nodes=[],
+            node=node("jig"),
+            incoming_nodes=[],
+            outgoing_nodes=[],
         )
 
         assert m.find_adjacent_graph(node("jig.cli")) == ModuleNodeAdjacentGraph(

--- a/tests/visualizer/module_dependency/domain/model/test_master_graph.py
+++ b/tests/visualizer/module_dependency/domain/model/test_master_graph.py
@@ -1,5 +1,13 @@
 from jig.visualizer.module_dependency.domain.model.master_graph import MasterGraph
+from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_node_adjacent import (
+    ModuleNodeAdjacentGraph,
+)
 from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
+
+
+def node(name: str) -> ModuleNode:
+    return ModuleNode.from_str(name)
 
 
 def path(name: str) -> ModulePath:
@@ -25,3 +33,45 @@ class TestMasterGraph:
         assert master_graph.has_module(path("jig.cli.main")) is True
         assert master_graph.has_module(path("jig.collector.domain.source_file")) is True
         assert master_graph.has_module(path("jig.no_module")) is False
+
+    def test_find_node_adjacent_graph(self):
+        m = MasterGraph.from_tuple_list(
+            [
+                ("jig.collector.application", "jig.collector.domain.source_code"),
+                ("jig.collector.application", "jig.collector.domain.source_file"),
+                (
+                    "jig.collector.domain.source_code",
+                    "jig.collector.domain.source_file",
+                ),
+                ("jig.cli.main", "jig.collector.application"),
+            ]
+        )
+
+        assert m.find_adjacent_graph(node("none")) is None
+
+        assert m.find_adjacent_graph(node("jig")) == ModuleNodeAdjacentGraph(
+            node=node("jig"), incoming_nodes=[], outgoing_nodes=[],
+        )
+
+        assert m.find_adjacent_graph(node("jig.cli")) == ModuleNodeAdjacentGraph(
+            node=node("jig.cli"),
+            incoming_nodes=[],
+            outgoing_nodes=[node("jig.collector.application")],
+        )
+
+        assert m.find_adjacent_graph(node("jig.collector")) == ModuleNodeAdjacentGraph(
+            node=node("jig.collector"),
+            incoming_nodes=[node("jig.cli.main")],
+            outgoing_nodes=[],
+        )
+
+        assert m.find_adjacent_graph(
+            node("jig.collector.application")
+        ) == ModuleNodeAdjacentGraph(
+            node=node("jig.collector.application"),
+            incoming_nodes=[node("jig.cli.main")],
+            outgoing_nodes=[
+                node("jig.collector.domain.source_code"),
+                node("jig.collector.domain.source_file"),
+            ],
+        )

--- a/tests/visualizer/module_dependency/domain/value/test_cluster.py
+++ b/tests/visualizer/module_dependency/domain/value/test_cluster.py
@@ -19,6 +19,31 @@ class TestCluster:
         child_cluster.add(node("buzz"))
         assert c.is_empty is False
 
+    def test_list_all_nodes(self):
+        c = Cluster(node=node("foo"), children={node("foo.foo")})
+        assert c.list_all_nodes() == [node("foo"), node("foo.foo")]
+
+        child_cluster = Cluster(node=node("bar"), children={node("bar.bar")})
+        c.add_cluster(child_cluster)
+
+        assert c.list_all_nodes() == [
+            node("bar"),
+            node("bar.bar"),
+            node("foo"),
+            node("foo.foo"),
+        ]
+
+        grand_child_cluster = Cluster(node=node("buzz"), children={node("buzz.buzz")})
+        child_cluster.add_cluster(grand_child_cluster)
+        assert c.list_all_nodes() == [
+            node("bar"),
+            node("bar.bar"),
+            node("buzz"),
+            node("buzz.buzz"),
+            node("foo"),
+            node("foo.foo"),
+        ]
+
     def test_descendant_nodes(self):
         c = Cluster(node=node("jig"))
         assert c.descendant_nodes() == []

--- a/tests/visualizer/module_dependency/domain/value/test_cluster.py
+++ b/tests/visualizer/module_dependency/domain/value/test_cluster.py
@@ -79,9 +79,9 @@ class TestCluster:
         )
         c.add_cluster(child_cluster)
 
-        assert c.find_cluster(node("x")) is None
-        assert c.find_cluster(node("jig")) is None
-        assert c.find_cluster(node("jig.collector")) is child_cluster
+        assert c.find_cluster(path("x")) is None
+        assert c.find_cluster(path("jig")) is None
+        assert c.find_cluster(path("jig.collector")) is child_cluster
 
     def test_find_node_owner(self):
         c = Cluster(module_path=path("jig"), children={node("jig.cli")})

--- a/tests/visualizer/module_dependency/domain/value/test_cluster.py
+++ b/tests/visualizer/module_dependency/domain/value/test_cluster.py
@@ -13,10 +13,10 @@ def node(name: str) -> ModuleNode:
 
 class TestCluster:
     def test_is_empty(self):
-        c = Cluster(node=node("foo"))
+        c = Cluster(module_path=path("foo"))
         assert c.is_empty is True
 
-        child_cluster = Cluster(node=node("bar"))
+        child_cluster = Cluster(module_path=path("bar"))
         c.add_cluster(child_cluster)
 
         assert c.is_empty is True
@@ -25,10 +25,10 @@ class TestCluster:
         assert c.is_empty is False
 
     def test_list_all_modules(self):
-        c = Cluster(node=node("foo"), children={node("foo.foo")})
+        c = Cluster(module_path=path("foo"), children={node("foo.foo")})
         assert c.list_all_modules() == [path("foo"), path("foo.foo")]
 
-        child_cluster = Cluster(node=node("bar"), children={node("bar.bar")})
+        child_cluster = Cluster(module_path=path("bar"), children={node("bar.bar")})
         c.add_cluster(child_cluster)
 
         assert c.list_all_modules() == [
@@ -38,7 +38,9 @@ class TestCluster:
             path("foo.foo"),
         ]
 
-        grand_child_cluster = Cluster(node=node("buzz"), children={node("buzz.buzz")})
+        grand_child_cluster = Cluster(
+            module_path=path("buzz"), children={node("buzz.buzz")}
+        )
         child_cluster.add_cluster(grand_child_cluster)
         assert c.list_all_modules() == [
             path("bar"),
@@ -50,14 +52,14 @@ class TestCluster:
         ]
 
     def test_descendant_nodes(self):
-        c = Cluster(node=node("jig"))
+        c = Cluster(module_path=path("jig"))
         assert c.descendant_nodes() == []
 
         c.add(node("jig.cli"))
         assert c.descendant_nodes() == [node("jig.cli")]
 
         child_cluster = Cluster(
-            node=node("jig.collection"),
+            module_path=path("jig.collection"),
             children={node("jig.collector.domain"), node("jig.collector.application")},
         )
         c.add_cluster(child_cluster)
@@ -69,10 +71,11 @@ class TestCluster:
         ]
 
     def test_find_cluster(self):
-        c = Cluster(node=node("jig"), children={node("jig.cli")})
+        c = Cluster(module_path=path("jig"), children={node("jig.cli")})
 
         child_cluster = Cluster(
-            node=node("jig.collector"), children={node("jig.collector.application")}
+            module_path=path("jig.collector"),
+            children={node("jig.collector.application")},
         )
         c.add_cluster(child_cluster)
 
@@ -81,10 +84,11 @@ class TestCluster:
         assert c.find_cluster(node("jig.collector")) is child_cluster
 
     def test_find_node_owner(self):
-        c = Cluster(node=node("jig"), children={node("jig.cli")})
+        c = Cluster(module_path=path("jig"), children={node("jig.cli")})
 
         child_cluster = Cluster(
-            node=node("jig.collector"), children={node("jig.collector.application")}
+            module_path=path("jig.collector"),
+            children={node("jig.collector.application")},
         )
         c.add_cluster(child_cluster)
 
@@ -94,12 +98,12 @@ class TestCluster:
         assert c.find_node_owner(node("jig.collector.application")) == child_cluster
 
     def test_add(self):
-        c = Cluster(node=node("foo"))
+        c = Cluster(module_path=path("foo"))
         c.add(node=node("bar"))
         assert c.is_empty is False
 
     def test_remove(self):
-        c = Cluster(node=node("foo"), children={node("bar")})
+        c = Cluster(module_path=path("foo"), children={node("bar")})
         c.remove(node=node("bar"))
         assert c.is_empty is True
 
@@ -107,10 +111,11 @@ class TestCluster:
         assert c.is_empty is True
 
     def test_remove_with_child_cluster(self):
-        c = Cluster(node=node("jig"), children={node("jig.cli")})
+        c = Cluster(module_path=path("jig"), children={node("jig.cli")})
 
         child_cluster = Cluster(
-            node=node("jig.collector"), children={node("jig.collector.application")}
+            module_path=path("jig.collector"),
+            children={node("jig.collector.application")},
         )
         c.add_cluster(child_cluster)
 

--- a/tests/visualizer/module_dependency/domain/value/test_cluster.py
+++ b/tests/visualizer/module_dependency/domain/value/test_cluster.py
@@ -1,5 +1,10 @@
 from jig.visualizer.module_dependency.domain.value.cluster import Cluster
 from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
+
+
+def path(name: str) -> ModulePath:
+    return ModulePath(name)
 
 
 def node(name: str) -> ModuleNode:
@@ -19,29 +24,29 @@ class TestCluster:
         child_cluster.add(node("buzz"))
         assert c.is_empty is False
 
-    def test_list_all_nodes(self):
+    def test_list_all_modules(self):
         c = Cluster(node=node("foo"), children={node("foo.foo")})
-        assert c.list_all_nodes() == [node("foo"), node("foo.foo")]
+        assert c.list_all_modules() == [path("foo"), path("foo.foo")]
 
         child_cluster = Cluster(node=node("bar"), children={node("bar.bar")})
         c.add_cluster(child_cluster)
 
-        assert c.list_all_nodes() == [
-            node("bar"),
-            node("bar.bar"),
-            node("foo"),
-            node("foo.foo"),
+        assert c.list_all_modules() == [
+            path("bar"),
+            path("bar.bar"),
+            path("foo"),
+            path("foo.foo"),
         ]
 
         grand_child_cluster = Cluster(node=node("buzz"), children={node("buzz.buzz")})
         child_cluster.add_cluster(grand_child_cluster)
-        assert c.list_all_nodes() == [
-            node("bar"),
-            node("bar.bar"),
-            node("buzz"),
-            node("buzz.buzz"),
-            node("foo"),
-            node("foo.foo"),
+        assert c.list_all_modules() == [
+            path("bar"),
+            path("bar.bar"),
+            path("buzz"),
+            path("buzz.buzz"),
+            path("foo"),
+            path("foo.foo"),
         ]
 
     def test_descendant_nodes(self):

--- a/tests/visualizer/module_dependency/domain/value/test_module_path.py
+++ b/tests/visualizer/module_dependency/domain/value/test_module_path.py
@@ -10,6 +10,13 @@ class TestModulePath:
         assert module_path("jig").parts == ["jig"]
         assert module_path("jig.collector").parts == ["jig", "collector"]
 
+    def test_parent(self):
+        assert module_path("jig").parent() is None
+        assert module_path("jig.collector").parent() == module_path("jig")
+        assert module_path("jig.collector.domain").parent() == module_path(
+            "jig.collector"
+        )
+
     def test_path_level(self):
         assert module_path("a").path_level == 1
         assert module_path("foo").path_level == 1

--- a/tests/visualizer/module_dependency/presentation/renderer/test_cluster_renderer.py
+++ b/tests/visualizer/module_dependency/presentation/renderer/test_cluster_renderer.py
@@ -2,9 +2,14 @@ from graphviz import Digraph
 
 from jig.visualizer.module_dependency.domain.value.cluster import Cluster
 from jig.visualizer.module_dependency.domain.value.module_node import ModuleNode
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 from jig.visualizer.module_dependency.presentation.renderer.cluster_renderer import (
     ClusterRenderer,
 )
+
+
+def path(name: str) -> ModulePath:
+    return ModulePath(name)
 
 
 def node(name: str) -> ModuleNode:
@@ -14,7 +19,8 @@ def node(name: str) -> ModuleNode:
 class TestClusterRenderer:
     def test_render(self):
         cluster = Cluster(
-            node=node("jig"), children={node("jig.collector"), node("jig.analyzer")},
+            module_path=path("jig"),
+            children={node("jig.collector"), node("jig.analyzer")},
         )
         renderer = ClusterRenderer(cluster=cluster)
 
@@ -26,9 +32,9 @@ class TestClusterRenderer:
         assert str(renderer.render()) == str(g)
 
     def test_render__clusters(self):
-        cluster = Cluster(node=node("jig"), children={node("jig.analyzer")})
+        cluster = Cluster(module_path=path("jig"), children={node("jig.analyzer")})
         sub_cluster = Cluster(
-            node=node("jig.collector"),
+            module_path=path("jig.collector"),
             children={node("jig.collector.application"), node("jig.collector.domain")},
         )
         cluster.add_cluster(sub_cluster)

--- a/tests/visualizer/module_dependency/presentation/renderer/test_graph_renderer.py
+++ b/tests/visualizer/module_dependency/presentation/renderer/test_graph_renderer.py
@@ -10,9 +10,14 @@ from jig.visualizer.module_dependency.domain.value.module_node import (
     ModuleNode,
     ModuleNodeStyle,
 )
+from jig.visualizer.module_dependency.domain.value.module_path import ModulePath
 from jig.visualizer.module_dependency.presentation.renderer.graph_renderer import (
     GraphRenderer,
 )
+
+
+def path(name: str) -> ModulePath:
+    return ModulePath(name)
 
 
 def node(name: str) -> ModuleNode:
@@ -25,9 +30,9 @@ def edge(tail: str, head: str) -> ModuleEdge:
 
 class TestGraphRenderer:
     def test_render(self):
-        cluster = Cluster(node=node("jig"), children={node("jig.analyzer")})
+        cluster = Cluster(module_path=path("jig"), children={node("jig.analyzer")})
         sub_cluster = Cluster(
-            node=node("jig.collector"),
+            module_path=path("jig.collector"),
             children={node("jig.collector.application"), node("jig.collector.domain")},
         )
         cluster.add_cluster(sub_cluster)


### PR DESCRIPTION
実装に当たってClusterのModuleNodeをModulePathに変更するリファクタリングをしました。
（削除したノードを復元して、現在Graphに存在するノード（描画されるもの）にエッジをつなげる際、Clusterの持っているModuleNodeは対象にならず、紛らわしいのでModulePathに置き換えた）

その他に新しい概念として、MasterGraph から指定したノードに隣接するノードだけを含むサブグラフ（隣接グラフ: ModuleNodeAdjacentGraph）を返すメソッドを追加し、それを使ってエッジの復元をしています。

![image](https://user-images.githubusercontent.com/1888342/93049725-8da5b600-f69c-11ea-845a-8770a1f519ca.png)



